### PR TITLE
OCPBUGS-15235: [iRMC] Fix parse_driver_info bug enforcing SNMP v3 under FIPS mode

### DIFF
--- a/ironic/drivers/modules/irmc/common.py
+++ b/ironic/drivers/modules/irmc/common.py
@@ -51,6 +51,12 @@ IPMI_ENABLED_BY_DEFAULT_RANGES = {
 
 ELCM_STATUS_PATH = '/rest/v1/Oem/eLCM/eLCMStatus'
 
+# List of xxx_interface & implementation pair which uses SNMP internally
+# and iRMC driver supports
+INTERFACE_IMPL_LIST_WITH_SNMP = {
+    'inspect_interface': {'irmc', },
+    'power_interface': {'irmc', }}
+
 REQUIRED_PROPERTIES = {
     'irmc_address': _("IP address or hostname of the iRMC. Required."),
     'irmc_username': _("Username for the iRMC with administrator privileges. "
@@ -233,6 +239,12 @@ def _parse_snmp_driver_info(node, info):
     valid_versions = {"v1": snmp.SNMP_V1,
                       "v2c": snmp.SNMP_V2C,
                       "v3": snmp.SNMP_V3}
+
+    for int_name, impl_list in INTERFACE_IMPL_LIST_WITH_SNMP.items():
+        if getattr(node, int_name) in impl_list:
+            break
+    else:
+        return snmp_info
 
     if snmp_info['irmc_snmp_version'].lower() not in valid_versions:
         raise exception.InvalidParameterValue(_(

--- a/ironic/tests/unit/drivers/modules/irmc/test_common.py
+++ b/ironic/tests/unit/drivers/modules/irmc/test_common.py
@@ -37,6 +37,8 @@ from ironic.tests.unit.objects import utils as obj_utils
 class BaseIRMCTest(db_base.DbTestCase):
 
     boot_interface = 'irmc-pxe'
+    inspect_interface = 'irmc'
+    power_interface = 'irmc'
 
     def setUp(self):
         super(BaseIRMCTest, self).setUp()
@@ -51,6 +53,8 @@ class BaseIRMCTest(db_base.DbTestCase):
             self.context,
             driver='irmc',
             boot_interface=self.boot_interface,
+            inspect_interface=self.inspect_interface,
+            power_interface=self.power_interface,
             driver_info=self.info,
             uuid=uuidutils.generate_uuid())
 
@@ -73,6 +77,44 @@ class IRMCValidateParametersTestCase(BaseIRMCTest):
         self.assertEqual(161, info['irmc_snmp_port'])
         self.assertEqual('public', info['irmc_snmp_community'])
         self.assertTrue(info['irmc_verify_ca'])
+
+    @mock.patch.object(utils, 'is_fips_enabled',
+                       return_value=False, autospec=True)
+    def test_parse_snmp_driver_info_with_snmp(self, mock_check_fips):
+        test_list = [{'interfaces': [{'interface': 'inspect_interface',
+                                      'impl': 'irmc'},
+                                     {'interface': 'power_interface',
+                                      'impl': 'irmc'}],
+                      'snmp': True},
+                     {'interfaces': [{'interface': 'inspect_interface',
+                                      'impl': 'inspector'},
+                                     {'interface': 'power_interface',
+                                      'impl': 'irmc'}],
+                      'snmp': True},
+                     {'interfaces': [{'interface': 'inspect_interface',
+                                      'impl': 'irmc'},
+                                     {'interface': 'power_interface',
+                                      'impl': 'ipmitool'}],
+                      'snmp': True},
+                     {'interfaces': [{'interface': 'inspect_interface',
+                                      'impl': 'inspector'},
+                                     {'interface': 'power_interface',
+                                      'impl': 'ipmitool'}],
+                      'snmp': False}
+                     ]
+
+        for t_conf in test_list:
+            with self.subTest(t_conf=t_conf):
+                for int_conf in t_conf['interfaces']:
+                    setattr(self.node, int_conf['interface'], int_conf['impl'])
+                irmc_common.parse_driver_info(self.node)
+
+                if t_conf['snmp']:
+                    mock_check_fips.assert_called()
+                else:
+                    mock_check_fips.assert_not_called()
+
+                mock_check_fips.reset_mock()
 
     def test_parse_driver_info_snmpv3(self):
         self.node.driver_info['irmc_snmp_version'] = 'v3'

--- a/releasenotes/notes/fix-irmc-enforcing-snmpv3-with-fips-e45971d363925ec3.yaml
+++ b/releasenotes/notes/fix-irmc-enforcing-snmpv3-with-fips-e45971d363925ec3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes bug of iRMC driver in parse_driver_info where, if FIPS is enabled,
+    SNMP version is always required to be version 3 even though iRMC driver's
+    xxx_interface doesn't use SNMP actually.


### PR DESCRIPTION
This patch fixes a condition where iRMC driver interfaces would have the FIPS enforcement logic check applied if the SNMP version was not set to SNMP v3, even if the interfaces did not use SNMP.

With this patch, if FIPS enabled, iRMC driver enforces SNMP version to be version 3 only when any xxx_interface of iRMC driver actually uses SNMP.

Story: 2010713
Task: 47879
Change-Id: I774c459a5e11b7cd01f7a65754d5a2c7cc573476 (cherry picked from commit 3f09bdcf952621b75e7a0dfc9e001542b2bcc94f)