### PR TITLE
Prevent MissingAttribute error when supportedApplyTime missing

### DIFF
--- a/ironic/drivers/modules/redfish/bios.py
+++ b/ironic/drivers/modules/redfish/bios.py
@@ -230,12 +230,16 @@ class RedfishBIOS(base.BIOSInterface):
             LOG.debug('Apply BIOS configuration for node %(node_uuid)s: '
                       '%(settings)r', {'node_uuid': task.node.uuid,
                                        'settings': settings})
-
-            if bios.supported_apply_times and (
-                    sushy.APPLY_TIME_ON_RESET in bios.supported_apply_times):
-                apply_time = sushy.APPLY_TIME_ON_RESET
-            else:
-                apply_time = None
+            apply_time = None
+            try:
+                if bios.supported_apply_times and (
+                        sushy.APPLY_TIME_ON_RESET in
+                        bios.supported_apply_times):
+                    apply_time = sushy.APPLY_TIME_ON_RESET
+            except AttributeError:
+                LOG.warning('SupportedApplyTimes attribute missing for BIOS'
+                            ' configuration on node %(node_uuid)s: ',
+                            {'node_uuid': task.node.uuid})
 
             try:
                 bios.set_attributes(attributes, apply_time=apply_time)

--- a/releasenotes/notes/handle-missing-bios-supportedapplytimes-attr-fbacc7ca3c399e83.yaml
+++ b/releasenotes/notes/handle-missing-bios-supportedapplytimes-attr-fbacc7ca3c399e83.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes the bug where provisioning a Redfish managed node fails if changing
+    BIOS settings is attempted on a BMC that doesn't provide
+    supportedApplyTime information. This is done by adding handling of
+    AttributeError exception in apply_configuration() method.


### PR DESCRIPTION
On some hardware, supportedApplyTime attribute may not be listed under Redfish BIOS settings URL. This patch adds handling of this case to prevent failure on attempt of updating BIOS settings.

Change-Id: I40359973fd832146cb2b179bfa447a308078e83d (cherry picked from commit f93712d7a61100b72a0d7fc236b727a8655ca8c9)