### PR TITLE
4.13 - Retry connecting vmedia through a DVD device if available

### DIFF
--- a/releasenotes/notes/handle-dvd-only-vmedia-f4971a013a8aafd0.yaml
+++ b/releasenotes/notes/handle-dvd-only-vmedia-f4971a013a8aafd0.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes the bug where provisioning a Redfish managed node fails if the BMC
+    only supports virtual media devices limited to MediaType of DVD (and not
+    CD). Also ddds handling of BadRequest exceptions while iterating through
+    the list of virtual media devices. This fix is needed to successfully
+    provision machines such as Cisco UCSB and UCSX.


### PR DESCRIPTION
This commit is a cherry-pick of https://github.com/openshift/openstack-ironic/commit/e33289816409f712c66d9b98755b3f3658121569 to 4.12 Branch

Trackers:
4.14 - https://issues.redhat.com/browse/OCPBUGS-14926
4.13 - https://issues.redhat.com/browse/OCPBUGS-19078