### PR TITLE
Synchronize 4.14 and 4.15

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -60,11 +60,13 @@ postgresql-client [platform:dpkg]
 # postgresql-devel [platform:rpm]
 postgresql-server [platform:rpm]
 mariadb [platform:rpm]
-mariadb-server [platform:rpm]
+mariadb-server [platform:rpm platform:debian-bookworm]
 # mariadb-devel [platform:rpm]
 dev-db/mariadb [platform:gentoo]
-mysql-client [platform:dpkg]
-mysql-server [platform:dpkg]
+mysql-client [platform:dpkg !platform:debian-bookworm]
+mysql-server [platform:dpkg !platform:debian-bookworm]
+mariadb-client [platform:debian-bookworm]
+
 # libmysqlclient-dev [platform:dpkg]
 # gettext and graphviz are needed by doc builds only. For transition,
 # have them in both doc and test.

--- a/devstack/lib/ironic
+++ b/devstack/lib/ironic
@@ -382,6 +382,7 @@ IRONIC_UWSGI=$IRONIC_BIN_DIR/ironic-api-wsgi
 
 # Lets support IPv6 testing!
 IRONIC_IP_VERSION=${IRONIC_IP_VERSION:-${IP_VERSION:-4}}
+IRONIC_IPV6_ADDRESS_MODE=${IRONIC_IPV6_ADDRESS_MODE:-dhcpv6-stateless}
 
 # Ironic connection info.  Note the port must be specified.
 if is_service_enabled tls-proxy; then
@@ -1364,7 +1365,7 @@ function configure_ironic_provision_network {
         # with our global address, but iPXE seems to have in
         # consistant behavior in this configuration with devstack.
         # so we will setup a dummy interface and use that.
-        if ! $( ping -c1 -w1 $IRONIC_HOST_IPV6 ); then
+        if ! ( ping -c1 -w1 $IRONIC_HOST_IPV6 ); then
             # But before we create an interface, lets make sure it is
             # not already working.
             sudo ip link add magicv6 type dummy
@@ -1424,11 +1425,9 @@ function configure_ironic_provision_network {
                 --subnet-range $IRONIC_PROVISION_SUBNET_PREFIX \
                 --dns-nameserver 8.8.8.8 -f value -c id)"
         else
-            # NOTE(TheJulia): Consider changing this to stateful to support UEFI once we move
-            # CI to Ubuntu Jammy as it will support v6 and v4 UEFI firmware driven boot ops.
             subnet_id="$(openstack --os-cloud $OS_CLOUD subnet create --ip-version 6 \
-                --ipv6-address-mode dhcpv6-stateless \
-                --ipv6-ra-mode dhcpv6-stateless \
+                --ipv6-address-mode $IRONIC_IPV6_ADDRESS_MODE \
+                --ipv6-ra-mode $IRONIC_IPV6_ADDRESS_MODE \
                 --dns-nameserver 2001:4860:4860::8888 \
                 ${net_segment_id:+--network-segment $net_segment_id} \
                 $IRONIC_PROVISION_PROVIDER_SUBNET_NAME \

--- a/doc/source/admin/index.rst
+++ b/doc/source/admin/index.rst
@@ -32,6 +32,7 @@ the services.
    Booting a Ramdisk or an ISO <ramdisk-boot>
    Hardware Burn-in <hardware-burn-in>
    Vendor Passthru <vendor-passthru>
+   Servicing <servicing>
 
 Drivers, Hardware Types and Hardware Interfaces
 -----------------------------------------------

--- a/doc/source/admin/servicing.rst
+++ b/doc/source/admin/servicing.rst
@@ -1,0 +1,205 @@
+.. _servicing:
+
+==============
+Node servicing
+==============
+
+Overview
+========
+
+In order to better enable operators to modify existing nodes, Ironic has
+introduced the model of Node Servicing, where you can take a node in
+``active`` state, modify it using steps similar to Deploy Steps or manual
+cleaning through the Cleaning subsystem.
+
+For more information on cleaning, please see :ref:`cleaning`.
+
+Major differences
+=================
+
+Service steps do not contain an automatic execution model, which is intrinisc
+to the standard deployment and "automated" cleaning workflows. This *may*
+change at some point in the future.
+
+This also means that while a priority value *can* be supplied, it is not
+presently utilized.
+
+Similarities to Cleaning and Deployment
+=======================================
+
+Similar to Clean and Deploy steps, when invoked an operator can validate
+the curent running steps by viewing the ``driver_internal_info`` field
+looking for a ``service_steps`` field. The *current* step being executed
+can be viewed using the baremetal node ``service_step`` field, which is a
+top level field.
+
+Service steps are internally decorated on driver interface methods utilizing
+decorator. This means service steps do not *automatically* expose clean and
+deploy steps to be executed at any time. The Ironic development team took a
+cautious and intentional approach behind methods which are decorated. Besides,
+some clean and deployment steps are geared explicitly for operating in
+that mode, and would not be suitable to be triggered outside of the
+original workflow it was designed for use in.
+
+Available Steps
+===============
+
+
+Executing Service Steps
+=======================
+
+In order for manual cleaning to work, you may need to configure a
+`Servicing Network`_.
+
+Starting manual cleaning via API
+--------------------------------
+
+Servicing can only be performed when a node is in the ``active``
+provision state. The REST API request to initiate it is available in
+API version 1.87 and higher::
+
+    PUT /v1/nodes/<node_ident>/states/provision
+
+(Additional information is available `here <https://docs.openstack.org/api-ref/baremetal/index.html?expanded=change-node-provision-state-detail#change-node-provision-state>`_.)
+
+This API will allow operators to put a node directly into ``servicing``
+provision state from ``active`` provision state via 'target': 'service'.
+The PUT will also require the argument 'service_steps' to be specified. This
+is an ordered list of steps. A step is represented by a
+dictionary (JSON), in the form::
+
+  {
+      "interface": "<interface>",
+      "step": "<name of step>",
+      "args": {"<arg1>": "<value1>", ..., "<argn>": <valuen>}
+  }
+
+The 'interface' and 'step' keys are required for all steps. If a cleaning step
+method takes keyword arguments, the 'args' key may be specified. It
+is a dictionary of keyword variable arguments, with each keyword-argument entry
+being <name>: <value>.
+
+If any step is missing a required keyword argument, servicing will not be
+performed and the node will be put in ``service failed`` provision state
+with an appropriate error message.
+
+If, during the servicing process, a service step determines that it has
+incorrect keyword arguments, all earlier steps will be performed and then the
+node will be put in ``service failed`` provision state with an appropriate
+error message.
+
+An example of the request body for this API::
+
+  {
+    "target":"service",
+    "sevice_steps": [{
+      "interface": "raid",
+      "step": "apply_configuration",
+      "args": {"create_nonroot_volumes": True}
+    },
+    {
+      "interface": "vendor",
+      "step": "send_raw"
+      "args": {"raw_bytes": "0x00 0x00 0x00 0x00"}
+    }]
+  }
+
+In the above example, the node's RAID interface would apply the set RAID
+configuration, and then the vendor interface's ``send_raw`` step would be
+called to send a raw command to the BMC. Please note, ``send_raw`` is only
+available for the ``ipmi`` hardware type.
+
+Starting servicing via "openstack baremetal" CLI
+------------------------------------------------
+
+Servicing is available via the ``baremetal node service`` command,
+starting with Bare Metal API version 1.87.
+
+The argument ``--service-steps`` must be specified. Its value is one of:
+
+- a JSON string
+- path to a JSON file whose contents are passed to the API
+- '-', to read from stdin. This allows piping in the clean steps.
+  Using '-' to signify stdin is common in Unix utilities.
+
+Examples of doing this with a JSON string::
+
+    baremetal node service <node> \
+        --clean-steps '[{"interface": "deploy", "step": "example_task"}]'
+
+    baremetal node service <node> \
+        --service-steps '[{"interface": "deploy", "step": "example_task"}]'
+
+Or with a file::
+
+    baremetal node service <node> \
+        --service-steps my-service-steps.txt
+
+Or with stdin::
+
+    cat my-clean-steps.txt | baremetal node service <node> \
+        --service-steps -
+
+Available Steps in Ironic
+-------------------------
+
+ipmi hardware type
+~~~~~~~~~~~~~~~~~~
+
+vendor.send_raw
+^^^^^^^^^^^^^^^
+
+This step is covered in the :doc:`/admin/drivers/ipmitool` documentation
+and is usable as a service step in addition to a deploy step.
+
+redfish hardware type
+~~~~~~~~~~~~~~~~~~~~~
+
+bios.apply_configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is covered in the :ref:`bios` configuration documentation as it
+started as a cleaning step. It is a standardized cross-interface name.
+
+management.update_firmware
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This step is covered in the :doc:`/admin/drivers/redfish` and is intended
+to facilitate firmware updates via the BMC.
+
+raid.apply_configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+This step is covered in the :doc:`/admin/drivers/redfish` and is intended
+to facilitate applying raid configuration.
+
+raid.delete_configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This step is covered in the :doc:`/admin/drivers/redfish` and is intended
+to delete configuration.
+
+Agent
+~~~~~
+
+raid.apply_configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the standardized RAID passthrough interface for the agent, and can
+be leveraged like other RAID interfaces.
+
+
+Available steps in Ironic-Python-Agent
+--------------------------------------
+
+.. note::
+   Steps available from the agent will be populated once support has
+   merged in the agent to expose the steps to the ironic deployment.
+
+Servicing Network
+=================
+
+If you are using the Neutron DHCP provider (the default) you will also need to
+ensure you have configured a servicing network. This network will be used to
+boot the ramdisk for in-band service operations. This setting is configured
+utilizing the ``[neutron]servicing_network`` configuration parameter.

--- a/driver-requirements.txt
+++ b/driver-requirements.txt
@@ -4,7 +4,7 @@
 # python projects they should package as optional dependencies for Ironic.
 
 # These are available on pypi
-proliantutils>=2.14.0
+proliantutils>=2.16.0
 pysnmp-lextudio>=5.0.0 # BSD
 pyasn1-lextudio>=1.1.0 # BSD
 pyasn1-modules-lextudio>=0.2.0 # BSD

--- a/ironic/cmd/__init__.py
+++ b/ironic/cmd/__init__.py
@@ -23,7 +23,7 @@ os.environ['EVENTLET_NO_GREENDNS'] = 'yes'
 
 import eventlet
 
-eventlet.monkey_patch(os=False)
+eventlet.monkey_patch()
 # Monkey patch the original current_thread to use the up-to-date _active
 # global variable. See https://bugs.launchpad.net/bugs/1863021 and
 # https://github.com/eventlet/eventlet/issues/592

--- a/ironic/common/pxe_utils.py
+++ b/ironic/common/pxe_utils.py
@@ -58,7 +58,6 @@ DHCPV6_BOOTFILE_NAME = '59'  # rfc5970
 # DHCPV6_BOOTFILE_PARAMS = '60'  # rfc5970
 DHCP_TFTP_SERVER_ADDRESS = '150'  # rfc5859
 DHCP_IPXE_ENCAP_OPTS = '175'  # Tentatively Assigned
-DHCP_TFTP_PATH_PREFIX = '210'  # rfc5071
 DHCP_SERVER_IP_ADDRESS = '255'  # dnsmasq server-ip-address
 
 DEPLOY_KERNEL_RAMDISK_LABELS = ['deploy_kernel', 'deploy_ramdisk']
@@ -562,16 +561,6 @@ def dhcp_options_for_instance(task, ipxe_enabled=False, url_boot=False,
     else:
         dhcp_opts.append({'opt_name': boot_file_param,
                           'opt_value': boot_file})
-        # 210 == tftp server path-prefix or tftp root, will be used to find
-        # pxelinux.cfg directory. The pxelinux.0 loader infers this information
-        # from it's own path, but Petitboot needs it to be specified by this
-        # option since it doesn't use pxelinux.0 loader.
-        if not url_boot:
-            # Enforce trailing slash
-            prefix = os.path.join(CONF.pxe.tftp_root, '')
-            dhcp_opts.append(
-                {'opt_name': DHCP_TFTP_PATH_PREFIX,
-                 'opt_value': prefix})
 
     if not url_boot:
         dhcp_opts.append({'opt_name': DHCP_TFTP_SERVER_NAME,

--- a/ironic/common/release_mappings.py
+++ b/ironic/common/release_mappings.py
@@ -573,9 +573,52 @@ RELEASE_MAPPING = {
             'VolumeTarget': ['1.0'],
         }
     },
+    '22.0': {
+        'api': '1.83',
+        'rpc': '1.55',
+        'objects': {
+            'Allocation': ['1.1'],
+            'BIOSSetting': ['1.1'],
+            'Node': ['1.38', '1.37'],
+            'NodeHistory': ['1.0'],
+            'NodeInventory': ['1.0'],
+            'Conductor': ['1.3'],
+            'Chassis': ['1.3'],
+            'Deployment': ['1.0'],
+            'DeployTemplate': ['1.1'],
+            'Port': ['1.11'],
+            'Portgroup': ['1.5'],
+            'Trait': ['1.0'],
+            'TraitList': ['1.0'],
+            'VolumeConnector': ['1.0'],
+            'VolumeTarget': ['1.0'],
+        }
+    },
+    '22.1': {
+        'api': '1.86',
+        'rpc': '1.56',
+        'objects': {
+            'Allocation': ['1.1'],
+            'BIOSSetting': ['1.1'],
+            'Node': ['1.39', '1.38', '1.37'],
+            'NodeHistory': ['1.0'],
+            'NodeInventory': ['1.0'],
+            'Conductor': ['1.3'],
+            'Chassis': ['1.3'],
+            'Deployment': ['1.0'],
+            'DeployTemplate': ['1.1'],
+            'Port': ['1.11'],
+            'Portgroup': ['1.5'],
+            'Trait': ['1.0'],
+            'TraitList': ['1.0'],
+            'VolumeConnector': ['1.0'],
+            'VolumeTarget': ['1.0'],
+            'FirmwareComponent': ['1.0'],
+        }
+    },
     'master': {
         'api': '1.87',
-        'rpc': '1.57',
+        'rpc': '1.58',
         'objects': {
             'Allocation': ['1.1'],
             'BIOSSetting': ['1.1'],

--- a/ironic/conductor/base_manager.py
+++ b/ironic/conductor/base_manager.py
@@ -24,6 +24,7 @@ from ironic_lib import mdns
 from oslo_db import exception as db_exception
 from oslo_log import log
 from oslo_utils import excutils
+from oslo_utils import netutils
 from oslo_utils import versionutils
 
 from ironic.common import context as ironic_context
@@ -44,7 +45,7 @@ from ironic.db import api as dbapi
 from ironic.drivers.modules import deploy_utils
 from ironic import objects
 from ironic.objects import fields as obj_fields
-
+from ironic import version
 
 LOG = log.getLogger(__name__)
 
@@ -73,6 +74,15 @@ class BaseConductorManager(object):
         Under normal operation, this is also when the initial database
         connectivity is established for the conductor's normal operation.
         """
+        # Determine the hostname to utilize/register
+        if (CONF.rpc_transport == 'json-rpc'
+                and CONF.json_rpc.port != 8089
+                and self._use_jsonrpc_port()):
+            # in the event someone configures self.host
+            # as an ipv6 address...
+            host = netutils.escape_ipv6(self.host)
+            self.host = f'{host}:{CONF.json_rpc.port}'
+
         # NOTE(TheJulia) We need to clear locks early on in the process
         # of starting where the database shows we still hold them.
         # This must be done before we re-register our existence in the
@@ -223,6 +233,15 @@ class BaseConductorManager(object):
             self._publish_endpoint()
 
         self._started = True
+        LOG.debug('Started Ironic Conductor - %s',
+                  version.version_info.release_string())
+
+    def _use_jsonrpc_port(self):
+        """Determines if the JSON-RPC port can be used."""
+        release_ver = versions.RELEASE_MAPPING.get(CONF.pin_release_version)
+        version_cap = (release_ver['rpc'] if release_ver
+                       else self.RPC_API_VERSION)
+        return versionutils.is_compatible('1.58', version_cap)
 
     def _use_groups(self):
         release_ver = versions.RELEASE_MAPPING.get(CONF.pin_release_version)

--- a/ironic/conductor/manager.py
+++ b/ironic/conductor/manager.py
@@ -94,7 +94,7 @@ class ConductorManager(base_manager.BaseConductorManager):
     # NOTE(rloo): This must be in sync with rpcapi.ConductorAPI's.
     # NOTE(pas-ha): This also must be in sync with
     #               ironic.common.release_mappings.RELEASE_MAPPING['master']
-    RPC_API_VERSION = '1.57'
+    RPC_API_VERSION = '1.58'
 
     target = messaging.Target(version=RPC_API_VERSION)
 

--- a/ironic/conductor/rpcapi.py
+++ b/ironic/conductor/rpcapi.py
@@ -154,12 +154,13 @@ class ConductorAPI(object):
     |    1.55 - Added change_node_boot_mode
     |    1.56 - Added continue_inspection
     |    1.57 - Added do_node_service
+    |    1.58 - Added support for json-rpc port usage
     """
 
     # NOTE(rloo): This must be in sync with manager.ConductorManager's.
     # NOTE(pas-ha): This also must be in sync with
     #               ironic.common.release_mappings.RELEASE_MAPPING['master']
-    RPC_API_VERSION = '1.57'
+    RPC_API_VERSION = '1.58'
 
     def __init__(self, topic=None):
         super(ConductorAPI, self).__init__()

--- a/ironic/conductor/servicing.py
+++ b/ironic/conductor/servicing.py
@@ -322,7 +322,7 @@ def do_node_service_abort(task):
         return
 
     last_error = get_last_error(node)
-    info_message = _('Clean operation aborted for node %s') % node.uuid
+    info_message = _('Service operation aborted for node %s') % node.uuid
     if node.service_step:
         info_message += (
             _(' during or after the completion of step "%s"')

--- a/ironic/conductor/steps.py
+++ b/ironic/conductor/steps.py
@@ -498,7 +498,7 @@ def set_node_service_steps(task, disable_ramdisk=False):
     :raises: InvalidParameterValue if there is a problem with the user's
              clean steps.
     :raises: NodeCleaningFailure if there was a problem getting the
-             clean steps.
+             service steps.
     """
     node = task.node
     steps = _validate_user_service_steps(
@@ -848,7 +848,7 @@ def _validate_user_service_steps(task, user_steps, disable_ramdisk=False):
     :raises: InvalidParameterValue if validation of clean steps fails.
     :raises: NodeCleaningFailure if there was a problem getting the
         clean steps from the driver.
-    :return: validated clean steps update with information from the driver
+    :return: validated service steps update with information from the driver
     """
     # We call with enabled = False below so we pickup auto-disabled
     # steps, since service steps are not automagic like cleaning can be.

--- a/ironic/conf/inspector.py
+++ b/ironic/conf/inspector.py
@@ -20,13 +20,15 @@ from ironic.conf import auth
 
 VALID_ADD_PORTS_VALUES = {
     'all': _('all MAC addresses'),
-    'active': _('MAC addresses of NIC\'s with IP addresses'),
+    'active': _('MAC addresses of NICs with IP addresses'),
     'pxe': _('only the MAC address of the PXE NIC'),
     'disabled': _('do not create any ports'),
 }
 VALID_KEEP_PORTS_VALUES = {
-    'all': _('keep even ports with MAC\'s not present in the inventory'),
-    'present': _('keep only ports with MAC\'s present in the inventory'),
+    'all': _('keep all ports, even ones with MAC addresses that are not '
+             'present in the inventory'),
+    'present': _('keep only ports with MAC addresses present in '
+                 'the inventory'),
     'added': _('keep only ports determined by the add_ports option'),
 }
 

--- a/ironic/drivers/modules/agent.py
+++ b/ironic/drivers/modules/agent.py
@@ -657,6 +657,8 @@ class AgentRAID(base.RAIDInterface):
         return agent_base.get_steps(task, 'deploy', interface='raid')
 
     @METRICS.timer('AgentRAID.apply_configuration')
+    @base.service_step(priority=0,
+                       argsinfo=_RAID_APPLY_CONFIGURATION_ARGSINFO)
     @base.deploy_step(priority=0,
                       argsinfo=_RAID_APPLY_CONFIGURATION_ARGSINFO)
     def apply_configuration(self, task, raid_config,

--- a/ironic/drivers/modules/agent_base.py
+++ b/ironic/drivers/modules/agent_base.py
@@ -651,6 +651,10 @@ class HeartbeatMixin(object):
                         'processing (will retry on the next heartbeat)',
                         task.node.uuid)
             return
+        except Exception as e:
+            LOG.warning('Node %s failed to lock for a heartbeat operation '
+                        'with an unknown cause. Error: %s', task.node.uuid, e)
+            return
 
         node = task.node
         LOG.debug('Heartbeat from node %s in state %s (target state %s)',
@@ -812,11 +816,11 @@ class AgentBaseMixin(object):
         """Boot into the agent to prepare for service.
 
         :param task: a TaskManager object containing the node
-        :raises: NodeCleaningFailure, NetworkError if: the previous cleaning
-            ports cannot be removed or if new cleaning ports cannot be created.
+        :raises: NodeServiceFailure, NetworkError if: the previous service
+            ports cannot be removed or if new service ports cannot be created.
         :raises: InvalidParameterValue if cleaning network UUID config option
             has an invalid value.
-        :returns: states.CLEANWAIT to signify an asynchronous prepare
+        :returns: states.SERVICEWAIT to signify an asynchronous prepare
         """
         result = deploy_utils.prepare_inband_service(task)
         if result is None:
@@ -826,11 +830,11 @@ class AgentBaseMixin(object):
 
     @METRICS.timer('AgentBaseMixin.tear_down_service')
     def tear_down_service(self, task):
-        """Clean up the PXE and DHCP files after cleaning.
+        """Clean up the PXE and DHCP files after service.
 
         :param task: a TaskManager object containing the node
-        :raises: NodeServiceFailure, NetworkError if the cleaning ports cannot
-            be removed
+        :raises: NodeServiceFailure, NetworkError if the servicing ports
+            cannot be removed
         """
         deploy_utils.tear_down_inband_service(
             task)

--- a/ironic/drivers/modules/ipmitool.py
+++ b/ironic/drivers/modules/ipmitool.py
@@ -1390,6 +1390,8 @@ class VendorPassthru(base.VendorInterface):
     }
 
     @METRICS.timer('VendorPassthru.send_raw')
+    @base.service_step(priority=0,
+                       argsinfo=_send_raw_step_args)
     @base.deploy_step(priority=0,
                       argsinfo=_send_raw_step_args)
     @base.clean_step(priority=0, abortable=False,

--- a/ironic/drivers/modules/redfish/bios.py
+++ b/ironic/drivers/modules/redfish/bios.py
@@ -197,6 +197,7 @@ class RedfishBIOS(base.BIOSInterface):
                       {'node_uuid': node.uuid, 'attrs': current_attrs})
             self._clear_reboot_requested(task)
 
+    @base.service_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO)
     @base.clean_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO)
     @base.deploy_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO)
     @base.cache_bios_settings

--- a/ironic/drivers/modules/redfish/management.py
+++ b/ironic/drivers/modules/redfish/management.py
@@ -90,6 +90,14 @@ if sushy:
         v: k for k, v in INDICATOR_MAP.items()}
 
 
+_FIRMWARE_UPDATE_ARGS = {
+    'firmware_images': {
+        'description': (
+            'A list of firmware images to apply.'),
+        'required': True
+    }}
+
+
 def _set_boot_device(task, system, device, persistent=False):
     """An internal routine to set the boot device.
 
@@ -746,13 +754,10 @@ class RedfishManagement(base.ManagementInterface):
         return redfish_utils.get_system(task.node).manufacturer
 
     @METRICS.timer('RedfishManagement.update_firmware')
-    @base.clean_step(priority=0, abortable=False, argsinfo={
-        'firmware_images': {
-            'description': (
-                'A list of firmware images to apply.'
-            ),
-            'required': True
-        }})
+    @base.clean_step(priority=0, abortable=False,
+                     argsinfo=_FIRMWARE_UPDATE_ARGS)
+    @base.service_step(priority=0, abortable=False,
+                       argsinfo=_FIRMWARE_UPDATE_ARGS)
     def update_firmware(self, task, firmware_images):
         """Updates the firmware on the node.
 

--- a/ironic/drivers/modules/redfish/raid.py
+++ b/ironic/drivers/modules/redfish/raid.py
@@ -752,6 +752,8 @@ class RedfishRAID(base.RAIDInterface):
             raise exception.InvalidParameterValue(
                 _('interface type `scsi` not supported by Redfish RAID'))
 
+    @base.service_step(priority=0,
+                       argsinfo=base.RAID_APPLY_CONFIGURATION_ARGSINFO)
     @base.deploy_step(priority=0,
                       argsinfo=base.RAID_APPLY_CONFIGURATION_ARGSINFO)
     def apply_configuration(self, task, raid_config, create_root_volume=True,
@@ -850,6 +852,7 @@ class RedfishRAID(base.RAIDInterface):
 
     @base.clean_step(priority=0)
     @base.deploy_step(priority=0)
+    @base.service_step(priority=0)
     def delete_configuration(self, task):
         """Delete RAID configuration on the node.
 

--- a/ironic/tests/unit/__init__.py
+++ b/ironic/tests/unit/__init__.py
@@ -30,7 +30,7 @@ from oslo_log import log
 
 from ironic import objects
 
-eventlet.monkey_patch(os=False)
+eventlet.monkey_patch()
 
 log.register_options(cfg.CONF)
 log.setup(cfg.CONF, 'ironic')

--- a/ironic/tests/unit/api/base.py
+++ b/ironic/tests/unit/api/base.py
@@ -104,7 +104,6 @@ class BaseApiTest(db_base.DbTestCase):
         :param path_prefix: prefix of the url path
         """
         full_path = path_prefix + path
-        print('%s: %s %s' % (method.upper(), full_path, params))
         response = getattr(self.app, "%s_json" % method)(
             str(full_path),
             params=params,
@@ -113,7 +112,7 @@ class BaseApiTest(db_base.DbTestCase):
             extra_environ=extra_environ,
             expect_errors=expect_errors
         )
-        print('GOT:%s' % response)
+        print(method.upper(), full_path, "WITH", params, "GOT", str(response))
         return response
 
     def put_json(self, path, params, expect_errors=False, headers=None,
@@ -187,13 +186,12 @@ class BaseApiTest(db_base.DbTestCase):
         :param path_prefix: prefix of the url path
         """
         full_path = path_prefix + path
-        print('DELETE: %s' % (full_path))
         response = self.app.delete(str(full_path),
                                    headers=headers,
                                    status=status,
                                    extra_environ=extra_environ,
                                    expect_errors=expect_errors)
-        print('GOT:%s' % response)
+        print("DELETE", full_path, "GOT", str(response))
         return response
 
     def get_json(self, path, expect_errors=False, headers=None,
@@ -225,15 +223,14 @@ class BaseApiTest(db_base.DbTestCase):
         all_params.update(params)
         if q:
             all_params.update(query_params)
-        print('GET: %s %r' % (full_path, all_params))
         response = self.app.get(full_path,
                                 params=all_params,
                                 headers=headers,
                                 extra_environ=extra_environ,
                                 expect_errors=expect_errors)
+        print("GET", full_path, "WITH", params, "GOT", str(response))
         if not expect_errors:
             response = response.json
-        print('GOT:%s' % response)
         return response
 
     def validate_link(self, link, bookmark=False, headers=None):

--- a/ironic/tests/unit/api/controllers/v1/test_port.py
+++ b/ironic/tests/unit/api/controllers/v1/test_port.py
@@ -1114,7 +1114,6 @@ class TestListPortsByShard(test_api_base.BaseApiTest):
 
         res = self.get_json('/ports?shard=shard1,shard2', headers=self.headers)
         self.assertEqual(2, len(res['ports']))
-        print(res['ports'][0])
         self.assertNotEqual(res['ports'][0]['address'], bad_shard_address)
         self.assertNotEqual(res['ports'][1]['address'], bad_shard_address)
 

--- a/ironic/tests/unit/api/test_acl.py
+++ b/ironic/tests/unit/api/test_acl.py
@@ -102,7 +102,6 @@ class TestACLBase(base.BaseApiTest):
         # in troubleshooting ACL testing. This is a pattern
         # followed in API unit testing in ironic, and
         # really does help.
-        print('API ACL Testing Path %s %s' % (method, path))
         if headers:
             for k, v in headers.items():
                 rheaders[k] = v.format(**self.format_data)
@@ -185,8 +184,6 @@ class TestACLBase(base.BaseApiTest):
         if assert_dict_contains:
             for k, v in assert_dict_contains.items():
                 self.assertIn(k, response)
-                print(k)
-                print(v)
                 if str(v) == "None":
                     # Compare since the variable loaded from the
                     # json ends up being null in json or None.
@@ -218,13 +215,6 @@ class TestACLBase(base.BaseApiTest):
                     # views, such as "other" admins being subjected to
                     # a filtered view in these cases.
                     self.assertEqual(0, len(items))
-
-        # NOTE(TheJulia): API tests in Ironic tend to have a pattern
-        # to print request and response data to aid in development
-        # and troubleshooting. As such the prints should remain,
-        # at least until we are through primary development of the
-        # this test suite.
-        print('ACL Test GOT %s' % response)
 
 
 @ddt.ddt

--- a/ironic/tests/unit/common/test_neutron.py
+++ b/ironic/tests/unit/common/test_neutron.py
@@ -678,7 +678,6 @@ class TestNeutronNetworkActions(db_base.DbTestCase):
 
         network_data = neutron.get_neutron_port_data('port1', 'vif1')
 
-        print(network_data)
         expected_port = {
             'id': 'port1',
             'type': 'vif',

--- a/ironic/tests/unit/common/test_pxe_utils.py
+++ b/ironic/tests/unit/common/test_pxe_utils.py
@@ -895,9 +895,6 @@ class TestPXEUtils(db_base.DbTestCase):
             expected_info = [{'opt_name': '67',
                               'opt_value': bootfile,
                               'ip_version': ip_version},
-                             {'opt_name': '210',
-                              'opt_value': '/tftp-path/',
-                              'ip_version': ip_version},
                              {'opt_name': '66',
                               'opt_value': '192.0.2.1',
                               'ip_version': ip_version},
@@ -2165,8 +2162,6 @@ class iPXEBuildConfigOptionsTestCase(db_base.DbTestCase):
         if iso_boot:
             self.node.instance_info = {'boot_iso': 'http://test.url/file.iso'}
             self.node.save()
-            print(expected_options)
-            print(image_info)
             iso_url = os.path.join(http_url, self.node.uuid, 'boot_iso')
             expected_options.update(
                 {

--- a/ironic/tests/unit/conductor/test_base_manager.py
+++ b/ironic/tests/unit/conductor/test_base_manager.py
@@ -311,6 +311,33 @@ class StartStopTestCase(mgr_utils.ServiceSetUpMixin, db_base.DbTestCase):
         # 3 without reuse of the database connection.
         self.assertEqual(2, mock_dbapi.call_count)
 
+    def test_start_with_json_rpc(self):
+        CONF.set_override('rpc_transport', 'json-rpc')
+        CONF.set_override('host', 'foo.bar.baz')
+        self._start_service()
+        res = objects.Conductor.get_by_hostname(self.context, self.hostname)
+        self.assertEqual(self.hostname, res['hostname'])
+
+    def test_start_with_json_rpc_port(self):
+        CONF.set_override('rpc_transport', 'json-rpc')
+        CONF.set_override('host', 'foo.bar.baz')
+        CONF.set_override('port', 8192, group='json_rpc')
+
+        self._start_service()
+        res = objects.Conductor.get_by_hostname(self.context,
+                                                self.service.host)
+        self.assertEqual(f'{self.hostname}:8192', res['hostname'])
+
+    def test_start_without_jsonrpc_port_pined_version(self):
+        CONF.set_override('rpc_transport', 'json-rpc')
+        CONF.set_override('host', 'foo.bar.baz')
+        CONF.set_override('port', 8192, group='json_rpc')
+        CONF.set_override('pin_release_version', '21.4')
+        self._start_service()
+        res = objects.Conductor.get_by_hostname(self.context,
+                                                self.service.host)
+        self.assertEqual(self.hostname, res['hostname'])
+
 
 class KeepAliveTestCase(mgr_utils.ServiceSetUpMixin, db_base.DbTestCase):
     def test__conductor_service_record_keepalive(self):

--- a/releasenotes/notes/23.0-prelude-bobcat-ad7c24f666c22ebf.yaml
+++ b/releasenotes/notes/23.0-prelude-bobcat-ad7c24f666c22ebf.yaml
@@ -1,0 +1,17 @@
+---
+prelude: |
+    Ironic is proud to announce the release of 23.0, the capstone release of a
+    six month OpenStack 2023.2 (Bobcat) cycle.
+
+    Our focus this cycle has been on improving the ability for operators to
+    secure and service their Ironic nodes. There are also, as always, a myriad
+    of quality of life fixes, including improvements to sqlite support,
+    and graceful shutdown of conductors.
+
+    We hope the latest release of Ironic serves you well!
+upgrade: |
+    Ironic 23.0 is part of the OpenStack 2023.2 (Bobcat) release. This a
+    non-SLURP release, meaning users of a 2023.1 (Antelope) cycle Ironic release
+    can upgrade directly to the release accompanying 2024.1 (Caracal) when
+    available. For more information, please visit
+    `Release Cadence Adjustment <https://governance.openstack.org/tc/resolutions/20220210-release-cadence-adjustment.html?_ga=2.126966605.1175089434.1694620440-1981816456.1685478379>`_.

--- a/releasenotes/notes/remove-400a563030224c4f.yaml
+++ b/releasenotes/notes/remove-400a563030224c4f.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    While investigating `bug 2033430 <https://bugs.launchpad.net/ironic/+bug/2033430>`_
+    we discovered we were emitting DHCP option 210 *only* with OVN, and never
+    emitted it with dnsmasq because it was not being set previously. Our
+    internal notes also indicated this was for PXELinux support, but was
+    never actually needed. As it was excess, and redundant configuration
+    being provided to Neutron, it has been removed.

--- a/releasenotes/notes/use-port-in-hostname-for-jsonrpc-cdcd2c20a68a22c1.yaml
+++ b/releasenotes/notes/use-port-in-hostname-for-jsonrpc-cdcd2c20a68a22c1.yaml
@@ -1,0 +1,16 @@
+features:
+  - |
+    Adds the storage of the ``[json_rpc]port`` configuration value to the
+    internal conductor hostname field when the ``[DEFAULT]rpc_transport``
+    setting is set to "json-rpc". This allows deployments to utilize varying
+    port configurations for JSON-RPC. As a result of this change, the RPC
+    API version has been incremented to ``1.57`` and the feature is not
+    available until any ``[DEFAULT]pin_release_version`` setting is removed.
+upgrade:
+  - |
+    Operators utilizing JSON-RPC transport to conductors with a non-default
+    port configuration should expect to see the hash ring layout change as
+    the port number is now included in the hash ring calculation. This will
+    only occur once the hash ring pin has been removed.
+  - Requires ``ironic-lib`` version *5.5.0* for the json-rpc port to be
+    properly set and utilized.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,12 @@ pbr>=3.1.1 # Apache-2.0
 SQLAlchemy>=1.4.0 # MIT
 alembic>=1.4.2 # MIT
 automaton>=1.9.0 # Apache-2.0
-eventlet!=0.18.3,!=0.20.1,>=0.18.2 # MIT
+eventlet>=0.30.1 # MIT
 WebOb>=1.7.1 # MIT
 python-cinderclient!=4.0.0,>=3.3.0 # Apache-2.0
 python-glanceclient>=2.8.0 # Apache-2.0
 keystoneauth1>=4.2.0 # Apache-2.0
-ironic-lib>=5.4.0 # Apache-2.0
+ironic-lib>=5.5.0 # Apache-2.0
 python-swiftclient>=3.2.0 # Apache-2.0
 pytz>=2013.6 # MIT
 stevedore>=1.29.0 # Apache-2.0

--- a/zuul.d/ironic-jobs.yaml
+++ b/zuul.d/ironic-jobs.yaml
@@ -696,7 +696,7 @@
     vars:
       tox_envlist: py3
     # The job only tests the latest and shouldn't be run on the stable branches
-    branches: ^(?!stable)
+    branches: ^master$
     required-projects:
       - name: github.com/sqlalchemy/sqlalchemy
         override-checkout: main

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -26,7 +26,10 @@
         - ironic-standalone-redfish
         - ironic-tempest-bios-redfish-pxe
         - ironic-tempest-uefi-redfish-vmedia
-        - ironic-tempest-wholedisk-bios-snmp-pxe
+        # NOTE(TheJulia): Moving to not-voting due to bug
+        # https://bugs.launchpad.net/ironic/+bug/2034588
+        - ironic-tempest-wholedisk-bios-snmp-pxe:
+            voting: false
         - ironic-tempest-partition-uefi-ipmi-pxe
         # NOTE(TheJulia) Marking multinode non-voting on 20210311
         # Due to a high failure rate on limestone where the compute1
@@ -57,7 +60,7 @@
             voting: false
         - ironic-inspector-tempest-rbac-scope-enforced:
             voting: false
-        - bifrost-integration-tinyipa-ubuntu-focal:
+        - bifrost-integration-tinyipa-ubuntu-jammy:
             voting: false
         - bifrost-integration-redfish-vmedia-uefi-centos-9:
             voting: false
@@ -79,7 +82,9 @@
         - ironic-standalone-redfish
         - ironic-tempest-bios-redfish-pxe
         - ironic-tempest-uefi-redfish-vmedia
-        - ironic-tempest-wholedisk-bios-snmp-pxe
+        # NOTE(stevebaker): Disabled due to bug
+        # https://bugs.launchpad.net/ironic/+bug/2034588
+        # - ironic-tempest-wholedisk-bios-snmp-pxe
         - ironic-tempest-partition-uefi-ipmi-pxe
         # NOTE(TheJulia): Disabled multinode on 20210311 due to Limestone
         # seeming to be 


### PR DESCRIPTION
- Fix minor grammar issues in the help for new inspector options
- devstack - fix IPv6 ping
- Utilize the JSON-RPC port
- Correct bindep.txt entries for bookworm
- Add missing release mappings for 22.0 and 22.1
- Fully monkey patch eventlet for consistent behavior
- PXE: Remove DHCP option 210 from being set
- log the version of the conductor starting
- Log an exception from heartbeat
- Add service steps and initial docs
- DB: Only re-query for a lock holder if we cannot lock
- Update proliantutils driver requirements for bobcat
- [CI] Unblock CI by fixing job regex and non-voting snmp
- Fix two places that can cause issues under SQLite
- CI: Remove ubuntu focal job
- devstack - configurable ipv6 address mode
- [releasenotes] Prelude for 2023.2/bobcat
- Remove most prints for unit tests
