### PR TITLE
Redfish: wait for secure boot state change if it's not immediate

### DIFF
--- a/api-ref/source/baremetal-api-v1-node-management.inc
+++ b/api-ref/source/baremetal-api-v1-node-management.inc
@@ -306,6 +306,10 @@ Change Node Boot Mode
 
 Request a change to the Node's boot mode.
 
+.. note::
+   Depending on the driver and the underlying hardware, changing boot mode may
+   result in an automatic reboot.
+
 .. versionadded:: 1.76
    A change in node's boot mode can be requested.
 
@@ -340,6 +344,10 @@ Change Node Secure Boot
 .. rest_method:: PUT /v1/nodes/{node_ident}/states/secure_boot
 
 Request a change to the Node's secure boot state.
+
+.. note::
+   Depending on the driver and the underlying hardware, changing the secure
+   boot state may result in an automatic reboot.
 
 .. versionadded:: 1.76
    A change in node's secure boot state can be requested.

--- a/doc/source/admin/drivers/redfish.rst
+++ b/doc/source/admin/drivers/redfish.rst
@@ -140,6 +140,22 @@ Two clean and deploy steps are provided for key management:
 ``management.clear_secure_boot_keys``
     removes all secure boot keys from the node.
 
+Rebooting on boot mode changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While some hardware is able to change the boot mode or the `UEFI secure boot`_
+state immediately, other models may require a reboot for such a change to be
+applied. Furthermore, some hardware models cannot change the boot mode and the
+secure boot state simultaneously, requiring several reboots.
+
+The Bare Metal service refreshes the System resource after issuing a PATCH
+request against it. If the expected change is not observed, the node is
+rebooted, and the Bare Metal service waits until the change is applied. In the
+end, the previous power state is restored.
+
+This logic makes changing boot configuration more robust at the expense of
+several reboots in the worst case.
+
 Out-Of-Band inspection
 ======================
 

--- a/ironic/conf/redfish.py
+++ b/ironic/conf/redfish.py
@@ -115,6 +115,12 @@ opts = [
                default=60,
                help=_('Number of seconds to wait between checking for '
                       'failed raid config tasks')),
+    cfg.IntOpt('boot_mode_config_timeout',
+               min=0,
+               default=900,
+               help=_('Number of seconds to wait for boot mode or secure '
+                      'boot status change to take effect after a reboot. '
+                      'Set to 0 to disable waiting.')),
 ]
 
 

--- a/releasenotes/notes/uefi-and-secureboot-waits-a783215327164e2c.yaml
+++ b/releasenotes/notes/uefi-and-secureboot-waits-a783215327164e2c.yaml
@@ -1,0 +1,20 @@
+---
+fixes:
+  - |
+    While updating boot mode or secure boot state in the Redfish driver,
+    the node is now rebooted if the change is not detected on the System
+    resource refresh. Ironic then waits up to
+    ``[redfish]boot_mode_config_timeout`` seconds until the change is applied.
+upgrade:
+  - |
+    Changing the boot mode or the secure boot state via the direct API
+    (``/v1/nodes/{node_ident}/states/boot_mode`` and
+    ``/v1/nodes/{node_ident}/states/secure_boot`` accordingly) may now
+    result in a reboot. This happens when the change cannot be applied
+    immediately. Previously, the change would be applied whenever the next
+    reboot happens for any unrelated reason, causing inconsistent behavior.
+issues:
+  - |
+    When boot mode needs to be changed during provisioning, an additional
+    reboot may happen on certain hardware. This is to ensure consistent
+    behavior when any boot setting change results in a separate internal job.


### PR DESCRIPTION
We have discovered hardware that only applies boot mode / secure boot
changes during a reboot. Furthermore, the same hardware cannot update
both at the same time. To err on the safe side, reboot and wait for
the value to change if it's not changed immediately.

Jira: https://issues.redhat.com/browse/OCPBUGS-19884
Co-Authored-By: Jacob Anders <janders@redhat.com>
Change-Id: I318940a76be531f453f0f5cf31a59cba16febf57
(cherry picked from commit 6487b958136e41d2f672c2d80845b876f37b0561)
