### PR TITLE
UPSTREAM: <carry>: add ironic-merge-bot to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
   - derekhiggins
   - dtantsur
   - elfosardo
+  - ironic-merge-bot
   - iurygregory
   - rhjanders
   - zaneb


### PR DESCRIPTION
This should grant enough permissions to start CI jobs without human intervention, besides having PRs pre-approved.