### PR TITLE
Use per-node external_http_url for boot ISO

### DIFF
--- a/ironic/drivers/modules/image_utils.py
+++ b/ironic/drivers/modules/image_utils.py
@@ -544,8 +544,9 @@ def _prepare_iso_image(task, kernel_href, ramdisk_href,
 
         iso_object_name = _get_name(task.node, prefix='boot', suffix='.iso')
 
+        node_http_url = task.node.driver_info.get("external_http_url")
         image_url = img_handler.publish_image(
-            boot_iso_tmp_file, iso_object_name)
+            boot_iso_tmp_file, iso_object_name, node_http_url)
 
     LOG.debug("Created ISO %(name)s in object store for node %(node)s, "
               "exposed as temporary URL "

--- a/ironic/tests/unit/drivers/modules/test_image_utils.py
+++ b/ironic/tests/unit/drivers/modules/test_image_utils.py
@@ -578,7 +578,7 @@ class RedfishImageUtilsTestCase(db_base.DbTestCase):
             object_name = 'boot-%s.iso' % task.node.uuid
 
             mock_publish_image.assert_called_once_with(
-                mock.ANY, mock.ANY, object_name)
+                mock.ANY, mock.ANY, object_name, None)
 
             mock_create_boot_iso.assert_called_once_with(
                 mock.ANY, mock.ANY, 'http://kernel/img', 'http://ramdisk/img',
@@ -611,6 +611,38 @@ class RedfishImageUtilsTestCase(db_base.DbTestCase):
     @mock.patch.object(image_utils.ImageHandler, 'publish_image',
                        autospec=True)
     @mock.patch.object(images, 'create_boot_iso', autospec=True)
+    def test__prepare_iso_image_with_node_external_http_url(
+            self, mock_create_boot_iso, mock_publish_image):
+        self.config(default_boot_mode='uefi', group='deploy')
+        with task_manager.acquire(self.context, self.node.uuid,
+                                  shared=True) as task:
+            override_url = 'https://node.external/'
+            task.node.driver_info.update(external_http_url=override_url)
+
+            expected_url = 'https://node.external/c.f?e=f'
+            mock_publish_image.return_value = expected_url
+
+            url = image_utils._prepare_iso_image(
+                task, 'http://kernel/img', 'http://ramdisk/img',
+                'http://bootloader/img', root_uuid=task.node.uuid)
+
+            object_name = 'boot-%s.iso' % task.node.uuid
+
+            mock_publish_image.assert_called_once_with(
+                mock.ANY, mock.ANY, object_name, override_url)
+
+            mock_create_boot_iso.assert_called_once_with(
+                mock.ANY, mock.ANY, 'http://kernel/img', 'http://ramdisk/img',
+                boot_mode='uefi', esp_image_href='http://bootloader/img',
+                kernel_params=mock.ANY,
+                root_uuid='1be26c0b-03f2-4d2e-ae87-c02d7f33c123',
+                inject_files=None)
+
+            self.assertEqual(expected_url, url)
+
+    @mock.patch.object(image_utils.ImageHandler, 'publish_image',
+                       autospec=True)
+    @mock.patch.object(images, 'create_boot_iso', autospec=True)
     def test__prepare_iso_image_bios(
             self, mock_create_boot_iso, mock_publish_image):
         self.config(default_boot_mode='bios', group='deploy')
@@ -628,7 +660,7 @@ class RedfishImageUtilsTestCase(db_base.DbTestCase):
             object_name = 'boot-%s.iso' % task.node.uuid
 
             mock_publish_image.assert_called_once_with(
-                mock.ANY, mock.ANY, object_name)
+                mock.ANY, mock.ANY, object_name, None)
 
             mock_create_boot_iso.assert_called_once_with(
                 mock.ANY, mock.ANY, 'http://kernel/img', 'http://ramdisk/img',

--- a/releasenotes/notes/node-iso-external_http_url-c5e3fa9ae4960dd6.yaml
+++ b/releasenotes/notes/node-iso-external_http_url-c5e3fa9ae4960dd6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The per-node ``external_http_url`` setting in the driver info is now used
+    for a boot ISO. Previously this setting was only used for a config floppy.


### PR DESCRIPTION
When the per-node external_http_url feature was introduced by c197a2d8b24e2fa4c5e7901e448da1b0c93fcd26, it only applied to a config floppy. This fix ensures that it is also used for the boot ISO, both when it is generated locally (by _prepare_iso_image()) or just cached locally (by prepare_remote_image()).

Change-Id: Ic241da6845b4d97fd29888e28cc1d9ee34e182c1 Closes-Bug: #2044314
(cherry picked from commit 0d59e25cf8ae3e531fcca46b20907014a9a92f09)