### PR TITLE
Handle internal server errors while configuring secure boot

### DIFF
--- a/ironic/tests/unit/drivers/modules/redfish/test_management.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_management.py
@@ -1627,6 +1627,9 @@ class RedfishManagementTestCase(db_base.DbTestCase):
         def side_effect(force):
             nonlocal attempts
             attempts -= 1
+            if attempts >= 2:
+                raise sushy.exceptions.ServerSideError(
+                    "POST", 'img-url', mock.MagicMock())
             if attempts <= 0:
                 fake_sb.enabled = True
 

--- a/releasenotes/notes/redfish-500-fea3a8f86c0aecc7.yaml
+++ b/releasenotes/notes/redfish-500-fea3a8f86c0aecc7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    When configuring secure boot via Redfish, internal server errors are now
+    retried for a longer period than by default, accounting for the SecureBoot
+    resource unavailability during configuration on some hardware.


### PR DESCRIPTION
At least on some Dell machines, the Redfish SecureBoot resource is
unavailable during configuration, GET requests return HTTP 503.
Sushy does retry these, but not for long enough (the error message
suggests at least 30 seconds, which would be too much to just integrate
in Sushy). This change treats internal errors the same way as
mismatching "enabled" value, i.e. just waits.

Change-Id: I676f48de6b6195a69ea76b4e8b45a034220db2fa
(cherry picked from commit a6e3a7f50cd8594520cf80fa4ef0a07646221809)
