### PR TITLE
Log node UUID and not entire node instance to avoid logging its driver_info field

### DIFF
--- a/ironic/conductor/cleaning.py
+++ b/ironic/conductor/cleaning.py
@@ -54,7 +54,7 @@ def do_node_clean(task, clean_steps=None, disable_ramdisk=False):
         how = ('API' if node.automated_clean is False else 'configuration')
         LOG.info('Automated cleaning is disabled via %(how)s, node %(node)s '
                  'has been successfully moved to AVAILABLE state',
-                 {'how': how, 'node': node})
+                 {'how': how, 'node': node.uuid})
         return
 
     # NOTE(dtantsur): this is only reachable during automated cleaning,

--- a/ironic/tests/unit/conductor/test_cleaning.py
+++ b/ironic/tests/unit/conductor/test_cleaning.py
@@ -165,9 +165,10 @@ class DoNodeCleanTestCase(db_base.DbTestCase):
     def test__do_node_clean_automated_cache_bios_unsupported(self):
         self._test__do_node_clean_cache_bios(enable_unsupported=True)
 
+    @mock.patch.object(cleaning, 'LOG', autospec=True)
     @mock.patch('ironic.drivers.modules.fake.FakePower.validate',
                 autospec=True)
-    def test__do_node_clean_automated_disabled(self, mock_validate):
+    def test__do_node_clean_automated_disabled(self, mock_validate, mock_log):
         self.config(automated_clean=False, group='conductor')
 
         node = obj_utils.create_test_node(
@@ -187,6 +188,12 @@ class DoNodeCleanTestCase(db_base.DbTestCase):
         self.assertEqual({}, node.clean_step)
         self.assertNotIn('clean_steps', node.driver_internal_info)
         self.assertNotIn('clean_step_index', node.driver_internal_info)
+        mock_log.info.assert_called_once_with("Automated cleaning is disabled "
+                                              "via %(how)s, node %(node)s has "
+                                              "been successfully moved to "
+                                              "AVAILABLE state",
+                                              {'how': 'configuration',
+                                               'node': node.uuid})
 
     @mock.patch('ironic.drivers.modules.fake.FakePower.validate',
                 autospec=True)

--- a/releasenotes/notes/remove-node-object-from-log-statement-f1b92a8ca26686c2.yaml
+++ b/releasenotes/notes/remove-node-object-from-log-statement-f1b92a8ca26686c2.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    Log the node UUID instead of the full node object in
+    ironic/conductor/cleaning.py, to avoid logging the node's driver_info
+    property (containing its BMC username and password).
+

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps=
     doc8~=1.1.0 # Apache-2.0
     pycodestyle>=2.0.0,<3.0.0 # MIT
     flake8-import-order~=0.18.0 # LGPLv3
-    Pygments~=2.17.0 # BSD
+    Pygments~=2.18.0 # BSD
     bashate~=2.1.0 # Apache-2.0
     -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
 allowlist_externals = bash


### PR DESCRIPTION
Backporting fix and unit test to 4.16