### PR TITLE
Set node "alive" when inspection finished

### DIFF
--- a/ironic/conductor/cleaning.py
+++ b/ironic/conductor/cleaning.py
@@ -95,6 +95,12 @@ def do_node_clean(task, clean_steps=None, disable_ramdisk=False):
                      'out-of-band only cleaning has been requested for node '
                      '%s', node.uuid)
             prepare_result = None
+    except exception.AgentConnectionFailed:
+        LOG.info('Agent is not yet running on node %(node)s, waiting for'
+                 ' agent to come up for fast track', {'node': node.uuid})
+        target_state = states.MANAGEABLE if manual_clean else None
+        task.process_event('wait', target_state=target_state)
+        return
     except Exception as e:
         msg = (_('Failed to prepare node %(node)s for cleaning: %(e)s')
                % {'node': node.uuid, 'e': e})

--- a/ironic/conductor/deployments.py
+++ b/ironic/conductor/deployments.py
@@ -187,6 +187,11 @@ def do_node_deploy(task, conductor_id=None, configdrive=None,
 
     try:
         task.driver.deploy.prepare(task)
+    except exception.AgentConnectionFailed:
+        LOG.info('Agent is not yet running on node %(node)s, waiting for agent'
+                 ' to come up for fast track', {'node': node.uuid})
+        task.process_event('wait')
+        return
     except exception.IronicException as e:
         with excutils.save_and_reraise_exception():
             utils.deploying_error_handler(

--- a/ironic/tests/unit/conductor/test_utils.py
+++ b/ironic/tests/unit/conductor/test_utils.py
@@ -2238,6 +2238,18 @@ class FastTrackTestCase(db_base.DbTestCase):
                 self.context, self.node.uuid, shared=False) as task:
             self.assertFalse(conductor_utils.is_fast_track(task))
 
+    def test_is_fast_track_inspected_no_heartbeat(self, mock_get_power):
+        mock_get_power.return_value = states.POWER_ON
+        self.node = obj_utils.create_test_node(
+            self.context, driver='fake-hardware',
+            uuid=uuidutils.generate_uuid(),
+            inspection_finished_at=timeutils.utcnow(),
+            power_state=states.POWER_ON
+        )
+        with task_manager.acquire(
+                self.context, self.node.uuid, shared=False) as task:
+            self.assertTrue(conductor_utils.is_fast_track(task))
+
     def test_is_fast_track_powered_after_heartbeat(self, mock_get_power):
         mock_get_power.return_value = states.POWER_ON
         with task_manager.acquire(

--- a/releasenotes/notes/set-node-alive-when-inspection-finished-1ec74828852eaeef.yaml
+++ b/releasenotes/notes/set-node-alive-when-inspection-finished-1ec74828852eaeef.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Set node "alive" and make it fast trackable
+    as soon as inspection is finished, in addition
+    add a wait for the agent to callback should
+    it not be available when fast track is attempted.


### PR DESCRIPTION
To make the node fast trackable as soon as
inspection finishes, in addition add a wait for the agent to callback should it not be available when
fast track is attempted.

Closes-Bug: #2078820

Change-Id: I8a95fc08cf355b7b745a565e3a05c9dc0875a63e