### PR TITLE
Checksum files before raw conversion

### DIFF
--- a/doc/source/admin/security.rst
+++ b/doc/source/admin/security.rst
@@ -19,6 +19,40 @@ OpenStack deployment.
 
 .. TODO: add "Multi-tenancy Considerations" section
 
+Image Checksums
+===============
+
+Ironic has long provided a capacity to supply and check a checksum for disk
+images being deployed. However, one aspect which Ironic has not asserted is
+"Why?" in terms of "Is it for security?" or "Is it for data integrity?".
+
+The answer is both to ensure a higher level of security with remote
+image files, *and* provide faster feedback should a image being transferred
+happens to be corrupted.
+
+Normally checksums are verified by the ``ironic-python-agent`` **OR** the
+deployment interface responsible for overall deployment operation. That being
+said, not *every* deployment interface relies on disk images which have
+checksums, and those deployment interfaces are for specific use cases which
+Ironic users leverage, outside of the "general" use case capabilities provided
+by the ``direct`` deployment interface.
+
+.. NOTE::
+   Use of the node ``instance_info/image_checksum`` field is discouraged
+   for integrated OpenStack Users as usage of the matching Glance Image
+   Service field is also deprecated. That being said, Ironic retains this
+   feature by popular demand while also enabling also retain simplified
+   operator interaction.
+   The newer field values supported by Glance are also specifically
+   supported by Ironic as ``instance_info/image_os_hash_value`` for
+   checksum values and ``instance_info/image_os_hash_algo`` field for
+   the checksum algorithm.
+
+.. WARNING::
+   Setting a checksum value to a URL is supported, *however* doing this is
+   making a "tradeoff" with security as the remote checksum *can* change.
+   Conductor support this functionality can be disabled using the
+   :oslo.config:option:`conductor.disable_support_for_checksum_files` setting.
 
 REST API: user roles and policy settings
 ========================================

--- a/ironic/common/checksum_utils.py
+++ b/ironic/common/checksum_utils.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2024 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import re
+import time
+from urllib import parse as urlparse
+
+from oslo_log import log as logging
+from oslo_utils import fileutils
+
+from ironic.common import exception
+from ironic.common.i18n import _
+from ironic.common import image_service
+from ironic.conf import CONF
+
+LOG = logging.getLogger(__name__)
+
+
+# REGEX matches for Checksum file payloads
+# If this list requires changes, it should be changed in
+# ironic-python-agent (extensions/standby.py) as well.
+
+MD5_MATCH = r"^([a-fA-F\d]{32})\s"  # MD5 at beginning of line
+MD5_MATCH_END = r"\s([a-fA-F\d]{32})$"  # MD5 at end of line
+MD5_MATCH_ONLY = r"^([a-fA-F\d]{32})$"  # MD5 only
+SHA256_MATCH = r"^([a-fA-F\d]{64})\s"  # SHA256 at beginning of line
+SHA256_MATCH_END = r"\s([a-fA-F\d]{64})$"  # SHA256 at end of line
+SHA256_MATCH_ONLY = r"^([a-fA-F\d]{64})$"  # SHA256 only
+SHA512_MATCH = r"^([a-fA-F\d]{128})\s"  # SHA512 at beginning of line
+SHA512_MATCH_END = r"\s([a-fA-F\d]{128})$"  # SHA512 at end of line
+SHA512_MATCH_ONLY = r"^([a-fA-F\d]{128})$"  # SHA512 only
+FILENAME_MATCH_END = r"\s[*]?{filename}$"  # Filename binary/text end of line
+FILENAME_MATCH_PARENTHESES = r"\s\({filename}\)\s"  # CentOS images
+
+CHECKSUM_MATCHERS = (MD5_MATCH, MD5_MATCH_END, SHA256_MATCH, SHA256_MATCH_END,
+                     SHA512_MATCH, SHA512_MATCH_END)
+CHECKSUM_ONLY_MATCHERS = (MD5_MATCH_ONLY, SHA256_MATCH_ONLY, SHA512_MATCH_ONLY)
+FILENAME_MATCHERS = (FILENAME_MATCH_END, FILENAME_MATCH_PARENTHESES)
+
+
+def validate_checksum(path, checksum, checksum_algo=None):
+    """Validate image checksum.
+
+    :param path: File path in the form of a string to calculate a checksum
+                 which is compared to the checksum field.
+    :param checksum: The supplied checksum value, a string, which will be
+                     compared to the file.
+    :param checksum_algo: The checksum type of the algorithm.
+    :raises: ImageChecksumError if the supplied data cannot be parsed or
+             if the supplied value does not match the supplied checksum
+             value.
+    """
+    # TODO(TheJilia): At some point, we likely need to compare
+    # the incoming checksum algorithm upfront, ut if one is invoked which
+    # is not supported, hashlib will raise ValueError.
+    use_checksum_algo = None
+    if ":" in checksum:
+        # A form of communicating the checksum algorithm is to delimit the
+        # type from the value. See ansible deploy interface where this
+        # is most evident.
+        split_checksum = checksum.split(":")
+        use_checksum = split_checksum[1]
+        use_checksum_algo = split_checksum[0]
+    else:
+        use_checksum = checksum
+    if not use_checksum_algo:
+        use_checksum_algo = checksum_algo
+    # If we have a zero length value, but we split it, we have
+    # invalid input. Also, checksum is what we expect, algorithm is
+    # optional. This guards against the split of a value which is
+    # image_checksum = "sha256:" which is a potential side effect of
+    # splitting the string.
+    if use_checksum == '':
+        raise exception.ImageChecksumError()
+
+    # Make everything lower case since we don't expect mixed case,
+    # but we may have human originated input on the supplied algorithm.
+    try:
+        if not use_checksum_algo:
+            # This is backwards compatible support for a bare checksum.
+            calculated = compute_image_checksum(path)
+        else:
+            calculated = compute_image_checksum(path,
+                                                use_checksum_algo.lower())
+    except ValueError:
+        # ValueError is raised when an invalid/unsupported/unknown
+        # checksum algorithm is invoked.
+        LOG.error("Failed to generate checksum for file %(path)s, possible "
+                  "invalid checksum algorithm: %(algo)s",
+                  {"path": path,
+                   "algo": use_checksum_algo})
+        raise exception.ImageChecksumAlgorithmFailure()
+    except OSError:
+        LOG.error("Failed to read file %(path)s to compute checksum.",
+                  {"path": path})
+        raise exception.ImageChecksumFileReadFailure()
+    if (use_checksum is not None
+        and calculated.lower() != use_checksum.lower()):
+        LOG.error("We were supplied a checksum value of %(supplied)s, but "
+                  "calculated a value of %(value)s. This is a fatal error.",
+                  {"supplied": use_checksum,
+                   "value": calculated})
+        raise exception.ImageChecksumError()
+
+
+def compute_image_checksum(image_path, algorithm='md5'):
+    """Compute checksum by given image path and algorithm.
+
+    :param image_path: The path to the file to undergo checksum calculation.
+    :param algorithm: The checksum algorithm to utilize. Defaults
+        to 'md5' due to historical support reasons in Ironic.
+    :returns: The calculated checksum value.
+    :raises: ValueError when the checksum algorithm is not supported
+       by the system.
+    """
+
+    time_start = time.time()
+    LOG.debug('Start computing %(algo)s checksum for image %(image)s.',
+              {'algo': algorithm, 'image': image_path})
+
+    checksum = fileutils.compute_file_checksum(image_path,
+                                               algorithm=algorithm)
+    time_elapsed = time.time() - time_start
+    LOG.debug('Computed %(algo)s checksum for image %(image)s in '
+              '%(delta).2f seconds, checksum value: %(checksum)s.',
+              {'algo': algorithm, 'image': image_path, 'delta': time_elapsed,
+               'checksum': checksum})
+    return checksum
+
+
+def get_checksum_and_algo(instance_info):
+    """Get and return the image checksum and algo.
+
+    :param instance_info: The node instance info, or newly updated/generated
+                          instance_info value.
+    :returns: A tuple containing two values, a checksum and algorithm,
+              if available.
+    """
+    checksum_algo = None
+    if 'image_os_hash_value' in instance_info.keys():
+        # A value set by image_os_hash_value supersedes other
+        # possible uses as it is specific.
+        checksum = instance_info.get('image_os_hash_value')
+        checksum_algo = instance_info.get('image_os_hash_algo')
+    else:
+        checksum = instance_info.get('image_checksum')
+        if is_checksum_url(checksum):
+            image_source = instance_info.get('image_source')
+            checksum = get_checksum_from_url(checksum, image_source)
+
+        # NOTE(TheJulia): This is all based on SHA-2 lengths.
+        # SHA-3 would require a hint and it would not be a fixed length.
+        # That said, SHA-2 is still valid and has not been withdrawn.
+        checksum_len = len(checksum)
+        if checksum_len == 128:
+            # SHA2-512 is 512 bits, 128 characters.
+            checksum_algo = "sha512"
+        elif checksum_len == 64:
+            checksum_algo = "sha256"
+
+        if checksum_len == 32 and not CONF.agent.allow_md5_checksum:
+            # MD5 not permitted and the checksum is the length of MD5
+            # and not otherwise defined.
+            LOG.error('Cannot compute the checksum as it uses MD5 '
+                      'and is disabled by configuration. If the checksum '
+                      'is *not* MD5, please specify the algorithm.')
+            raise exception.ImageChecksumAlgorithmFailure()
+
+    return checksum, checksum_algo
+
+
+def is_checksum_url(checksum):
+    """Identify if checksum is not a url.
+
+    :param checksum: The user supplied checksum value.
+    :returns: True if the checksum is a url, otherwise False.
+    :raises: ImageChecksumURLNotSupported should the conductor have this
+             support disabled.
+    """
+    if (checksum.startswith('http://') or checksum.startswith('https://')):
+        if CONF.conductor.disable_support_for_checksum_files:
+            raise exception.ImageChecksumURLNotSupported()
+        return True
+    else:
+        return False
+
+
+def get_checksum_from_url(checksum, image_source):
+    """Gets a checksum value based upon a remote checksum URL file.
+
+    :param checksum: The URL to the checksum URL content.
+    :param image_soource: The image source utilized to match with
+        the contents of the URL payload file.
+    :raises: ImageDownloadFailed when the checksum file cannot be
+        accessed or cannot be parsed.
+    """
+
+    LOG.debug('Attempting to download checksum from: %(checksum)s.',
+              {'checksum': checksum})
+
+    # Directly invoke the image service and get the checksum data.
+    resp = image_service.HttpImageService.get(checksum)
+    checksum_url = str(checksum)
+
+    # NOTE(TheJulia): The rest of this method is taken from
+    # ironic-python-agent. If a change is required here, it may
+    # be required in ironic-python-agent (extensions/standby.py).
+    lines = [line.strip() for line in resp.split('\n') if line.strip()]
+    if not lines:
+        raise exception.ImageDownloadFailed(image_href=checksum,
+                                            reason=_('Checksum file empty.'))
+    elif len(lines) == 1:
+        # Special case - checksums file with only the checksum itself
+        if ' ' not in lines[0]:
+            for matcher in CHECKSUM_ONLY_MATCHERS:
+                checksum = re.findall(matcher, lines[0])
+                if checksum:
+                    return checksum[0]
+            raise exception.ImageDownloadFailed(
+                image_href=checksum_url,
+                reason=(
+                    _("Invalid checksum file (No valid checksum found)")))
+    # FIXME(dtantsur): can we assume the same name for all images?
+    expected_fname = os.path.basename(urlparse.urlparse(
+        image_source).path)
+    for line in lines:
+        # Ignore comment lines
+        if line.startswith("#"):
+            continue
+
+        # Ignore checksums for other files
+        for matcher in FILENAME_MATCHERS:
+            if re.findall(matcher.format(filename=expected_fname), line):
+                break
+        else:
+            continue
+
+        for matcher in CHECKSUM_MATCHERS:
+            checksum = re.findall(matcher, line)
+            if checksum:
+                return checksum[0]
+
+    raise exception.ImageDownloadFailed(
+        image_href=checksum,
+        reason=(_("Checksum file does not contain name %s")
+                % expected_fname))

--- a/ironic/common/exception.py
+++ b/ironic/common/exception.py
@@ -893,3 +893,25 @@ class BootModeNotAllowed(Invalid):
 
 class InvalidImage(ImageUnacceptable):
     _msg_fmt = _("The requested image is not valid for use.")
+
+
+class ImageChecksumError(InvalidImage):
+    """Exception indicating checksum failed to match."""
+    _msg_fmt = _("The supplied image checksum is invalid or does not match.")
+
+
+class ImageChecksumAlgorithmFailure(InvalidImage):
+    """Cannot load the requested or required checksum algorithm."""
+    _msg_fmt = _("The requested image checksum algorithm cannot be loaded.")
+
+
+class ImageChecksumURLNotSupported(InvalidImage):
+    """Exception indicating we cannot support the remote checksum file."""
+    _msg_fmt = _("Use of remote checksum files is not supported.")
+
+
+class ImageChecksumFileReadFailure(InvalidImage):
+    """An OSError was raised when trying to read the file."""
+    _msg_fmt = _("Failed to read the file from local storage "
+                 "to perform a checksum operation.")
+    code = http_client.SERVICE_UNAVAILABLE

--- a/ironic/common/images.py
+++ b/ironic/common/images.py
@@ -28,6 +28,7 @@ from oslo_log import log as logging
 from oslo_utils import fileutils
 import pycdlib
 
+from ironic.common import checksum_utils
 from ironic.common import exception
 from ironic.common.glance_service import service_utils as glance_utils
 from ironic.common.i18n import _
@@ -386,9 +387,13 @@ def fetch_into(context, image_href, image_file):
               {'image_href': image_href, 'time': time.time() - start})
 
 
-def fetch(context, image_href, path, force_raw=False):
+def fetch(context, image_href, path, force_raw=False,
+          checksum=None, checksum_algo=None):
     with fileutils.remove_path_on_error(path):
         fetch_into(context, image_href, path)
+        if (not CONF.conductor.disable_file_checksum
+                and checksum):
+            checksum_utils.validate_checksum(path, checksum, checksum_algo)
     if force_raw:
         image_to_raw(image_href, path, "%s.part" % path)
 

--- a/ironic/conf/conductor.py
+++ b/ironic/conf/conductor.py
@@ -471,6 +471,28 @@ opts = [
                        'permitted for deployment with Ironic. If an image '
                        'format outside of this list is detected, the image '
                        'validation logic will fail the deployment process.')),
+    cfg.BoolOpt('disable_file_checksum',
+                default=False,
+                mutable=False,
+                help=_('Deprecated Security option: In the default case, '
+                       'image files have their checksums verified before '
+                       'undergoing additional conductor side actions such '
+                       'as image conversion. '
+                       'Enabling this option opens the risk of files being '
+                       'replaced at the source without the user\'s '
+                       'knowledge.'),
+                deprecated_for_removal=True),
+    cfg.BoolOpt('disable_support_for_checksum_files',
+                default=False,
+                mutable=False,
+                help=_('Security option: By default Ironic will attempt to '
+                       'retrieve a remote checksum file via HTTP(S) URL in '
+                       'order to validate an image download. This is '
+                       'functionality aligning with ironic-python-agent '
+                       'support for standalone users. Disabling this '
+                       'functionality by setting this option to True will '
+                       'create a more secure environment, however it may '
+                       'break users in an unexpected fashion.')),
 ]
 
 

--- a/ironic/tests/unit/common/test_checksum_utils.py
+++ b/ironic/tests/unit/common/test_checksum_utils.py
@@ -1,0 +1,211 @@
+# coding=utf-8
+
+# Copyright 2024 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest import mock
+
+from oslo_config import cfg
+
+from ironic.common import checksum_utils
+from ironic.common import exception
+from ironic.common import image_service
+from ironic.tests import base
+
+CONF = cfg.CONF
+
+
+@mock.patch.object(checksum_utils, 'compute_image_checksum',
+                   autospec=True)
+class IronicChecksumUtilsValidateTestCase(base.TestCase):
+
+    def test_validate_checksum(self, mock_compute):
+        mock_compute.return_value = 'f00'
+        checksum_utils.validate_checksum('path', 'f00', 'algo')
+        mock_compute.assert_called_once_with('path', 'algo')
+
+    def test_validate_checksum_mixed_case(self, mock_compute):
+        mock_compute.return_value = 'f00'
+        checksum_utils.validate_checksum('path', 'F00', 'ALGO')
+        mock_compute.assert_called_once_with('path', 'algo')
+
+    def test_validate_checksum_mixed_md5(self, mock_compute):
+        mock_compute.return_value = 'f00'
+        checksum_utils.validate_checksum('path', 'F00')
+        mock_compute.assert_called_once_with('path')
+
+    def test_validate_checksum_mismatch(self, mock_compute):
+        mock_compute.return_value = 'a00'
+        self.assertRaises(exception.ImageChecksumError,
+                          checksum_utils.validate_checksum,
+                          'path', 'f00', 'algo')
+        mock_compute.assert_called_once_with('path', 'algo')
+
+    def test_validate_checksum_hashlib_not_supports_algo(self, mock_compute):
+        mock_compute.side_effect = ValueError()
+        self.assertRaises(exception.ImageChecksumAlgorithmFailure,
+                          checksum_utils.validate_checksum,
+                          'path', 'f00', 'algo')
+        mock_compute.assert_called_once_with('path', 'algo')
+
+    def test_validate_checksum_file_not_found(self, mock_compute):
+        mock_compute.side_effect = OSError()
+        self.assertRaises(exception.ImageChecksumFileReadFailure,
+                          checksum_utils.validate_checksum,
+                          'path', 'f00', 'algo')
+        mock_compute.assert_called_once_with('path', 'algo')
+
+    def test_validate_checksum_mixed_case_delimited(self, mock_compute):
+        mock_compute.return_value = 'f00'
+        checksum_utils.validate_checksum('path', 'algo:F00')
+        mock_compute.assert_called_once_with('path', 'algo')
+
+
+class IronicChecksumUtilsTestCase(base.TestCase):
+
+    def test_is_checksum_url_string(self):
+        self.assertFalse(checksum_utils.is_checksum_url('f00'))
+
+    def test_is_checksum_url_file(self):
+        self.assertFalse(checksum_utils.is_checksum_url('file://foo'))
+
+    def test_is_checksum_url(self):
+        urls = ['http://foo.local/file',
+                'https://foo.local/file']
+        for url in urls:
+            self.assertTrue(checksum_utils.is_checksum_url(url))
+
+    def test_get_checksum_and_algo_image_checksum(self):
+        value = 'c46f2c98efe1cd246be1796cd842246e'
+        i_info = {'image_checksum': value}
+        csum, algo = checksum_utils.get_checksum_and_algo(i_info)
+        self.assertEqual(value, csum)
+        self.assertIsNone(algo)
+
+    def test_get_checksum_and_algo_image_checksum_not_allowed(self):
+        CONF.set_override('allow_md5_checksum', False, group='agent')
+        value = 'c46f2c98efe1cd246be1796cd842246e'
+        i_info = {'image_checksum': value}
+        self.assertRaises(exception.ImageChecksumAlgorithmFailure,
+                          checksum_utils.get_checksum_and_algo,
+                          i_info)
+
+    def test_get_checksum_and_algo_image_checksum_glance(self):
+        value = 'c46f2c98efe1cd246be1796cd842246e'
+        i_info = {'image_os_hash_value': value,
+                  'image_os_hash_algo': 'foobar'}
+        csum, algo = checksum_utils.get_checksum_and_algo(i_info)
+        self.assertEqual(value, csum)
+        self.assertEqual('foobar', algo)
+
+    def test_get_checksum_and_algo_image_checksum_sha256(self):
+        value = 'a' * 64
+        i_info = {'image_checksum': value}
+        csum, algo = checksum_utils.get_checksum_and_algo(i_info)
+        self.assertEqual(value, csum)
+        self.assertEqual('sha256', algo)
+
+    def test_get_checksum_and_algo_image_checksum_sha512(self):
+        value = 'f' * 128
+        i_info = {'image_checksum': value}
+        csum, algo = checksum_utils.get_checksum_and_algo(i_info)
+        self.assertEqual(value, csum)
+        self.assertEqual('sha512', algo)
+
+    @mock.patch.object(checksum_utils, 'get_checksum_from_url', autospec=True)
+    def test_get_checksum_and_algo_image_checksum_http_url(self, mock_get):
+        value = 'http://checksum-url'
+        i_info = {
+            'image_checksum': value,
+            'image_source': 'image-ref'
+        }
+        mock_get.return_value = 'f' * 64
+        csum, algo = checksum_utils.get_checksum_and_algo(i_info)
+        mock_get.assert_called_once_with(value, 'image-ref')
+        self.assertEqual('f' * 64, csum)
+        self.assertEqual('sha256', algo)
+
+    @mock.patch.object(checksum_utils, 'get_checksum_from_url', autospec=True)
+    def test_get_checksum_and_algo_image_checksum_https_url(self, mock_get):
+        value = 'https://checksum-url'
+        i_info = {
+            'image_checksum': value,
+            'image_source': 'image-ref'
+        }
+        mock_get.return_value = 'f' * 128
+        csum, algo = checksum_utils.get_checksum_and_algo(i_info)
+        mock_get.assert_called_once_with(value, 'image-ref')
+        self.assertEqual('f' * 128, csum)
+        self.assertEqual('sha512', algo)
+
+
+@mock.patch.object(image_service.HttpImageService, 'get',
+                   autospec=True)
+class IronicChecksumUtilsGetChecksumTestCase(base.TestCase):
+
+    def test_get_checksum_from_url_empty_response(self, mock_get):
+        mock_get.return_value = ''
+        error = ('Failed to download image https://checksum-url, '
+                 'reason: Checksum file empty.')
+        self.assertRaisesRegex(exception.ImageDownloadFailed,
+                               error,
+                               checksum_utils.get_checksum_from_url,
+                               'https://checksum-url',
+                               'https://image-url/file')
+        mock_get.assert_called_once_with('https://checksum-url')
+
+    def test_get_checksum_from_url_one_line(self, mock_get):
+        mock_get.return_value = 'a' * 32
+        csum = checksum_utils.get_checksum_from_url(
+            'https://checksum-url', 'https://image-url/file')
+        mock_get.assert_called_once_with('https://checksum-url')
+        self.assertEqual('a' * 32, csum)
+
+    def test_get_checksum_from_url_nomatch_line(self, mock_get):
+        mock_get.return_value = 'foobar'
+        # For some reason assertRaisesRegex really doesn't like
+        # the error. Easiest path is just to assertTrue the compare.
+        exc = self.assertRaises(exception.ImageDownloadFailed,
+                                checksum_utils.get_checksum_from_url,
+                                'https://checksum-url',
+                                'https://image-url/file')
+        self.assertTrue(
+            'Invalid checksum file (No valid checksum found' in str(exc))
+        mock_get.assert_called_once_with('https://checksum-url')
+
+    def test_get_checksum_from_url_multiline(self, mock_get):
+        test_csum = ('f2ca1bb6c7e907d06dafe4687e579fce76b37e4e9'
+                     '3b7605022da52e6ccc26fd2')
+        mock_get.return_value = ('fee f00\n%s file\nbar fee\nf00' % test_csum)
+        # For some reason assertRaisesRegex really doesn't like
+        # the error. Easiest path is just to assertTrue the compare.
+        checksum = checksum_utils.get_checksum_from_url(
+            'https://checksum-url',
+            'https://image-url/file')
+        self.assertEqual(test_csum, checksum)
+        mock_get.assert_called_once_with('https://checksum-url')
+
+    def test_get_checksum_from_url_multiline_no_file(self, mock_get):
+        test_csum = 'a' * 64
+        error = ("Failed to download image https://checksum-url, reason: "
+                 "Checksum file does not contain name file")
+        mock_get.return_value = ('f00\n%s\nbar\nf00' % test_csum)
+        # For some reason assertRaisesRegex really doesn't like
+        # the error. Easiest path is just to assertTrue the compare.
+        self.assertRaisesRegex(exception.ImageDownloadFailed,
+                               error,
+                               checksum_utils.get_checksum_from_url,
+                               'https://checksum-url',
+                               'https://image-url/file')
+        mock_get.assert_called_once_with('https://checksum-url')

--- a/ironic/tests/unit/drivers/modules/test_image_cache.py
+++ b/ironic/tests/unit/drivers/modules/test_image_cache.py
@@ -66,7 +66,8 @@ class TestImageCacheFetch(BaseTest):
         self.cache.fetch_image(self.uuid, self.dest_path)
         self.assertFalse(mock_download.called)
         mock_fetch.assert_called_once_with(
-            None, self.uuid, self.dest_path, True)
+            None, self.uuid, self.dest_path, True,
+            None, None, None)
         self.assertFalse(mock_clean_up.called)
         mock_image_service.assert_not_called()
 
@@ -83,7 +84,8 @@ class TestImageCacheFetch(BaseTest):
                           self.uuid, self.dest_path)
         self.assertFalse(mock_download.called)
         mock_fetch.assert_called_once_with(
-            None, self.uuid, self.dest_path, True)
+            None, self.uuid, self.dest_path, True,
+            None, None, None)
         self.assertFalse(mock_clean_up.called)
         mock_image_service.assert_not_called()
 
@@ -158,7 +160,8 @@ class TestImageCacheFetch(BaseTest):
         mock_download.assert_called_once_with(
             self.cache, self.uuid, self.master_path, self.dest_path,
             mock_image_service.return_value.show.return_value,
-            ctx=None, force_raw=True, expected_format=None)
+            ctx=None, force_raw=True, expected_format=None,
+            expected_checksum=None, expected_checksum_algo=None)
         mock_clean_up.assert_called_once_with(self.cache)
         mock_image_service.assert_called_once_with(self.uuid, context=None)
         mock_image_service.return_value.show.assert_called_once_with(self.uuid)
@@ -180,7 +183,8 @@ class TestImageCacheFetch(BaseTest):
         mock_download.assert_called_once_with(
             self.cache, self.uuid, self.master_path, self.dest_path,
             mock_image_service.return_value.show.return_value,
-            ctx=None, force_raw=True, expected_format=None)
+            ctx=None, force_raw=True, expected_format=None,
+            expected_checksum=None, expected_checksum_algo=None)
         mock_clean_up.assert_called_once_with(self.cache)
 
     def test_fetch_image_not_uuid(self, mock_download, mock_clean_up,
@@ -193,7 +197,8 @@ class TestImageCacheFetch(BaseTest):
         mock_download.assert_called_once_with(
             self.cache, href, master_path, self.dest_path,
             mock_image_service.return_value.show.return_value,
-            ctx=None, force_raw=True, expected_format=None)
+            ctx=None, force_raw=True, expected_format=None,
+            expected_checksum=None, expected_checksum_algo=None)
         self.assertTrue(mock_clean_up.called)
 
     def test_fetch_image_not_uuid_no_force_raw(self, mock_download,
@@ -202,11 +207,14 @@ class TestImageCacheFetch(BaseTest):
         href = u'http://abc.com/ubuntu.qcow2'
         href_converted = str(uuid.uuid5(uuid.NAMESPACE_URL, href))
         master_path = os.path.join(self.master_dir, href_converted)
-        self.cache.fetch_image(href, self.dest_path, force_raw=False)
+        self.cache.fetch_image(href, self.dest_path, force_raw=False,
+                               expected_checksum='f00',
+                               expected_checksum_algo='sha256')
         mock_download.assert_called_once_with(
             self.cache, href, master_path, self.dest_path,
             mock_image_service.return_value.show.return_value,
-            ctx=None, force_raw=False, expected_format=None)
+            ctx=None, force_raw=False, expected_format=None,
+            expected_checksum='f00', expected_checksum_algo='sha256')
         self.assertTrue(mock_clean_up.called)
 
 
@@ -214,7 +222,8 @@ class TestImageCacheFetch(BaseTest):
 class TestImageCacheDownload(BaseTest):
 
     def test__download_image(self, mock_fetch):
-        def _fake_fetch(ctx, uuid, tmp_path, *args):
+        def _fake_fetch(ctx, uuid, tmp_path, force_raw, expected_format,
+                        expected_checksum, expected_checksum_algo):
             self.assertEqual(self.uuid, uuid)
             self.assertNotEqual(self.dest_path, tmp_path)
             self.assertNotEqual(os.path.dirname(tmp_path), self.master_dir)
@@ -236,7 +245,8 @@ class TestImageCacheDownload(BaseTest):
         # Make sure we don't use any parts of the URL anywhere.
         url = "http://example.com/image.iso?secret=%s" % ("x" * 1000)
 
-        def _fake_fetch(ctx, href, tmp_path, *args):
+        def _fake_fetch(ctx, href, tmp_path, force_raw, expected_format,
+                        expected_checksum, expected_checksum_algo):
             self.assertEqual(url, href)
             self.assertNotEqual(self.dest_path, tmp_path)
             self.assertNotEqual(os.path.dirname(tmp_path), self.master_dir)
@@ -520,7 +530,8 @@ class TestImageCacheCleanUp(base.TestCase):
     @mock.patch.object(utils, 'rmtree_without_raise', autospec=True)
     @mock.patch.object(image_cache, '_fetch', autospec=True)
     def test_temp_images_not_cleaned(self, mock_fetch, mock_rmtree):
-        def _fake_fetch(ctx, uuid, tmp_path, *args):
+        def _fake_fetch(ctx, uuid, tmp_path, force_raw, expected_format,
+                        expected_checksum, expected_checksum_algo):
             with open(tmp_path, 'w') as fp:
                 fp.write("TEST" * 10)
 
@@ -774,9 +785,13 @@ class TestFetchCleanup(base.TestCase):
         mock_format_inspector.return_value = image_check
         mock_show.return_value = {}
         mock_size.return_value = 100
-        image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
+        image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True,
+                           expected_checksum='1234',
+                           expected_checksum_algo='md5')
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum='1234',
+                                           checksum_algo='md5')
         mock_clean.assert_called_once_with('/foo', 100)
         mock_raw.assert_called_once_with('fake-uuid', '/foo/bar',
                                          '/foo/bar.part')
@@ -808,7 +823,8 @@ class TestFetchCleanup(base.TestCase):
         mock_size.return_value = 100
         image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum=None, checksum_algo=None)
         mock_clean.assert_called_once_with('/foo', 100)
         mock_raw.assert_called_once_with('fake-uuid', '/foo/bar',
                                          '/foo/bar.part')
@@ -838,9 +854,13 @@ class TestFetchCleanup(base.TestCase):
         mock_exists.return_value = True
         mock_size.return_value = 100
         mock_image_show.return_value = {}
-        image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
+        image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True,
+                           expected_format=None, expected_checksum='f00',
+                           expected_checksum_algo='sha256')
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum='f00',
+                                           checksum_algo='sha256')
         mock_clean.assert_called_once_with('/foo', 100)
         mock_raw.assert_called_once_with('fake-uuid', '/foo/bar',
                                          '/foo/bar.part')
@@ -868,9 +888,13 @@ class TestFetchCleanup(base.TestCase):
         image_check.__str__.return_value = 'raw'
         image_check.safety_check.return_value = True
         mock_format_inspector.return_value = image_check
-        image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
+        image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True,
+                           expected_checksum='e00',
+                           expected_checksum_algo='sha256')
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum='e00',
+                                           checksum_algo='sha256')
         mock_clean.assert_not_called()
         mock_size.assert_not_called()
         mock_raw.assert_not_called()
@@ -898,9 +922,14 @@ class TestFetchCleanup(base.TestCase):
         self.assertRaises(exception.InvalidImage,
                           image_cache._fetch,
                           'fake', 'fake-uuid',
-                          '/foo/bar', force_raw=True)
+                          '/foo/bar', force_raw=True,
+                          expected_format=None,
+                          expected_checksum='a00',
+                          expected_checksum_algo='sha512')
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum='a00',
+                                           checksum_algo='sha512')
         mock_clean.assert_not_called()
         mock_size.assert_not_called()
         mock_raw.assert_not_called()
@@ -929,7 +958,8 @@ class TestFetchCleanup(base.TestCase):
                           'fake', 'fake-uuid',
                           '/foo/bar', force_raw=True)
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum=None, checksum_algo=None)
         mock_clean.assert_not_called()
         mock_size.assert_not_called()
         mock_raw.assert_not_called()
@@ -958,7 +988,8 @@ class TestFetchCleanup(base.TestCase):
 
         image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum=None, checksum_algo=None)
         mock_size.assert_has_calls([
             mock.call('/foo/bar.part', estimate=False),
             mock.call('/foo/bar.part', estimate=True),
@@ -995,7 +1026,8 @@ class TestFetchCleanup(base.TestCase):
         mock_size.return_value = 100
         image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum=None, checksum_algo=None)
         mock_clean.assert_not_called()
         mock_raw.assert_not_called()
         mock_remove.assert_not_called()
@@ -1026,7 +1058,8 @@ class TestFetchCleanup(base.TestCase):
         mock_size.return_value = 100
         image_cache._fetch('fake', 'fake-uuid', '/foo/bar', force_raw=True)
         mock_fetch.assert_called_once_with('fake', 'fake-uuid',
-                                           '/foo/bar.part', force_raw=False)
+                                           '/foo/bar.part', force_raw=False,
+                                           checksum=None, checksum_algo=None)
         mock_clean.assert_not_called()
         mock_raw.assert_not_called()
         mock_remove.assert_not_called()

--- a/releasenotes/notes/checksum-before-conversion-66d273b94fa2ba4d.yaml
+++ b/releasenotes/notes/checksum-before-conversion-66d273b94fa2ba4d.yaml
@@ -1,0 +1,44 @@
+---
+security:
+  - |
+    An issue in Ironic has been resolved where image checksums would not be
+    checked prior to the conversion of an image to a ``raw`` format image from
+    another image format.
+
+    With default settings, this normally would not take place, however the
+    ``image_download_source`` option, which is available to be set at a
+    ``node`` level for a single deployment, by default for that baremetal node
+    in all cases, or via the ``[agent]image_download_source`` configuration
+    option when set to ``local``. By default, this setting is ``http``.
+
+    This was in concert with the ``[DEFAULT]force_raw_images`` when set to
+    ``True``, which caused Ironic to download and convert the file.
+
+    In a fully integrated context of Ironic's use in a larger OpenStack
+    deployment, where images are coming from the Glance image service, the
+    previous pattern was not problematic. The overall issue was introduced as
+    a result of the capability to supply, cache, and convert a disk image
+    provided as a URL by an authenticated user.
+
+    Ironic will now validate the user supplied checksum prior to image
+    conversion on the conductor. This can be disabled using the
+    ``[conductor]disable_file_checksum`` configuration option.
+fixes:
+  - |
+    Fixes a security issue where Ironic would fail to checksum disk image
+    files it downloads when Ironic had been requested to download and convert
+    the image to a raw image format. This required the
+    ``image_download_source`` to be explicitly set to ``local``, which is not
+    the default.
+
+    This fix can be disabled by setting
+    ``[conductor]disable_file_checksum`` to ``True``, however this
+    option will be removed in new major Ironic releases.
+
+    As a result of this, parity has been introduced to align Ironic to
+    Ironic-Python-Agent's support for checksums used by ``standalone``
+    users of Ironic. This includes support for remote checksum files to be
+    supplied by URL, in order to prevent breaking existing users which may
+    have inadvertently been leveraging the prior code path. This support can
+    be disabled by setting
+    ``[conductor]disable_support_for_checksum_files`` to ``True``.


### PR DESCRIPTION
While working another issue, we discovered that support added to the ironic-conductor process combined the image_download_source option of "local" with the "force_raw" option resulted in a case where Ironic had no concept to checksum the files *before* the conductor process triggered an image format conversion and then records new checksum values.

In essence, this opened the user requested image file to be suspetible to a theoretical man-in-the-middle attack OR the remote server replacing the content with an unknown file, such as a new major version.

The is at odds with Ironic's security model where we do want to ensure the end user of ironic is asserting a known checksum for the image artifact they are deploying, so they are aware of the present state. Due to the risk, we chose to raise this as a CVE, as infrastructure operators should likely apply this patch.

As a note, if your *not* forcing all images to be raw format through the conductor, then this issue is likely not a major issue for you, but you should still apply the patch.

This is being tracked as CVE-2024-47211.

Closes-Bug: 2076289
Change-Id: Id6185b317aa6e4f4363ee49f77e688701995323a
Signed-off-by: Julia Kreger <juliaashleykreger@gmail.com>
(cherry picked from commit 00c5e0faf8e435bf3ceb24399ef0d853f3058590)