### PR TITLE
[4.18] Update Node Cache after Successful Clean/Service 

### DIFF
--- a/ironic/conductor/cleaning.py
+++ b/ironic/conductor/cleaning.py
@@ -272,6 +272,7 @@ def do_next_clean_step(task, step_index, disable_ramdisk=None):
             return utils.cleaning_error_handler(task, msg,
                                                 traceback=True,
                                                 tear_down_cleaning=False)
+    utils.node_update_cache(task)
     LOG.info('Node %s cleaning complete', node.uuid)
     event = 'manage' if manual_clean or node.retired else 'done'
     # NOTE(rloo): No need to specify target prov. state; we're done

--- a/ironic/conductor/servicing.py
+++ b/ironic/conductor/servicing.py
@@ -55,6 +55,8 @@ def do_node_service(task, service_steps=None, disable_ramdisk=False):
                                   disable_ramdisk)
     task.node.save()
 
+    utils.node_update_cache(task)
+
     # Allow the deploy driver to set up the ramdisk again (necessary for IPA)
     try:
         if not disable_ramdisk:
@@ -228,6 +230,7 @@ def _tear_down_node_service(task, disable_ramdisk):
             return utils.servicing_error_handler(task, msg,
                                                  traceback=True,
                                                  tear_down_service=False)
+    utils.node_update_cache(task)
     LOG.info('Node %s service complete.', task.node.uuid)
     task.process_event('done')
 

--- a/releasenotes/notes/update-node-cache-after-successful-servicing-cleaning-7433c493e31742b0.yaml
+++ b/releasenotes/notes/update-node-cache-after-successful-servicing-cleaning-7433c493e31742b0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Update the node cache after a successful servicing and cleaning.
+    This ensures the node information is correctly updated in the
+    database.


### PR DESCRIPTION
This commits makes sure we call update_node_cache
after we finish a successful cleaning/servicing.

Change-Id: I62403120c758caac38a4d2b3912a9c43f65161cc