### PR TITLE
disable ISO cache image format and safety checks

### DIFF
--- a/ironic/drivers/modules/image_utils.py
+++ b/ironic/drivers/modules/image_utils.py
@@ -155,7 +155,9 @@ class ISOImageCache(image_cache.ImageCache):
             # MiB -> B
             cache_size=CONF.deploy.iso_cache_size * 1024 * 1024,
             # min -> sec
-            cache_ttl=CONF.deploy.iso_cache_ttl * 60)
+            cache_ttl=CONF.deploy.iso_cache_ttl * 60,
+            # disable image format inspection and safety checks for ISO
+            disable_validation=True, force_raw=False)
 
 
 def _get_name(node, prefix='', suffix=''):

--- a/releasenotes/notes/disable_img_validation_iso-3d694a83576bf189.yaml
+++ b/releasenotes/notes/disable_img_validation_iso-3d694a83576bf189.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    The image format inspection and image safety check have been disabled
+    for ISO images cached by Ironic. The feature has been disabled in order
+    to fix issues originally described in bug 2091611. On occasion Ironic has
+    detected multiple image formats for ISO image that contained GPT, the
+    issue originated from the fact that by default the oslo_utils.imageutils
+    library handles the GPT partition table format as additional image format
+    but allows only 1 image format for each image and throws an error if it
+    detects gpt+iso. As the image inspection and safety check was intended to
+    fix a security problem related to qemu-img-tools and qcow images, it has
+    been decided that the inspection and safety check can be disabled ISO
+    images without degrading Ironic's security.


### PR DESCRIPTION
This commit:
  - Disables image format checks and safety checks for ISO disk image cacheing

After some discussion in the community it has been decided that instead of changing the format detection and safety check logic, disabling the format and safety checks have a smaller maintenance footprint.

Related-Bug: 2091611
Change-Id: Iff2be28c64a0469a3796003f3b8ed28d70631761