### PR TITLE
Fix CI - One unit/One CI job

### DIFF
--- a/ironic/tests/unit/drivers/modules/redfish/test_firmware.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_firmware.py
@@ -1944,15 +1944,28 @@ class RedfishFirmwareTestCase(db_base.DbTestCase):
             self.assertEqual(states.SERVICEWAIT, result)
 
     @mock.patch.object(deploy_utils, 'set_async_step_flags', autospec=True)
+    @mock.patch.object(redfish_utils, 'get_manager', autospec=True)
+    @mock.patch.object(redfish_utils, 'get_system', autospec=True)
     @mock.patch.object(redfish_fw.RedfishFirmware, '_execute_firmware_update',
                        autospec=True)
     @mock.patch.object(redfish_utils, 'get_update_service', autospec=True)
     def test_update_bmc_with_explicit_wait(self, mock_get_update_service,
                                            mock_execute_fw_update,
+                                           mock_get_system,
+                                           mock_get_manager,
                                            mock_set_async_flags):
         """Test BMC update with explicit wait."""
         settings = [{'component': 'bmc', 'url': 'http://bmc/v1.0.0',
                      'wait': 90}]
+
+        # Mock system
+        mock_system = mock.Mock()
+        mock_get_system.return_value = mock_system
+
+        # Mock BMC version reading
+        mock_manager = mock.Mock()
+        mock_manager.firmware_version = '1.0.0'
+        mock_get_manager.return_value = mock_manager
 
         # add task_monitor to the side effect
         mock_execute_fw_update.side_effect = self._mock_exc_fwup_side_effect

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -58,7 +58,9 @@
         # NOTE(TheJulia): At present, metal3 doesn't leverage
         # stable branches, and as far as we are aware these jobs
         # can be removed once this branch is made stable.
-        - metal3-integration
+        # NOTE(TheJulia): re-enable once the metal3 integration job
+        # is working again.
+        #- metal3-integration
         - metal3-ironic-standalone-operator-functional:
             voting: false
         # Non-voting jobs
@@ -99,7 +101,7 @@
         # NOTE(TheJulia): At present, metal3 doesn't leverage
         # stable branches, and as far as we are aware these jobs
         # can be removed once this branch is made stable.
-        - metal3-integration
+        #- metal3-integration
     experimental:
       jobs:
         # NOTE(dtantsur): this job is rarely used, no need to run it always.


### PR DESCRIPTION
Over the weekend it seems the Ironic project had a compound CI breakage where one of our CI jobs started failing combined with metal3-integration *also* being broken.

The unit test failure, I can't figure out "why today", but it is clear the test is getting hung up trying to actually exercise a sushy client. Fixing the mocking, the world becomes a happy place. In essence, the test was timing out but getting stuck in a time call most likely, so *shrug*.

Metal3-integration, thats being worked on, but its been broken for a few days. In the mean time, we're going to disable that job in the interest of keeping the gate working.

Assisted-By: Claude Code - Claude Sonnet 4.5
Change-Id: I894acb47db892f0fefbb5819d31a38b8d590217d