### PR TITLE
[4.20] Use shared lock for get_virtual_media conductor method

### DIFF
--- a/ironic/conductor/manager.py
+++ b/ironic/conductor/manager.py
@@ -4023,7 +4023,6 @@ class ConductorManager(base_manager.BaseConductorManager):
 
     @METRICS.timer('ConductorManager.get_virtual_media')
     @messaging.expected_exceptions(exception.InvalidParameterValue,
-                                   exception.NodeLocked,
                                    exception.UnsupportedDriverExtension)
     def get_virtual_media(self, context, node_id):
         """Get all virtual media devices from the node.
@@ -4034,14 +4033,13 @@ class ConductorManager(base_manager.BaseConductorManager):
                  this call.
         :raises: InvalidParameterValue if validation of management driver
                  interface failed.
-        :raises: NodeLocked if node is locked by another conductor.
         :raises: NoFreeConductorWorker when there is no free worker to start
                  async task.
 
         """
         LOG.debug("RPC get_virtual_media called for node %(node)s ",
                   {'node': node_id})
-        with task_manager.acquire(context, node_id,
+        with task_manager.acquire(context, node_id, shared=True,
                                   purpose='get virtual media devices') as task:
             task.driver.management.validate(task)
             return task.driver.management.get_virtual_media(task)

--- a/ironic/drivers/modules/redfish/management.py
+++ b/ironic/drivers/modules/redfish/management.py
@@ -1575,7 +1575,6 @@ class RedfishManagement(base.ManagementInterface):
             LOG.error(msg)
             raise exception.RedfishError(error=msg)
 
-    @task_manager.require_exclusive_lock
     def get_virtual_media(self, task):
         """Get all virtual media devices from the node.
 

--- a/ironic/tests/unit/conductor/test_manager.py
+++ b/ironic/tests/unit/conductor/test_manager.py
@@ -9328,3 +9328,33 @@ class VirtualMediaTestCase(mgr_utils.ServiceSetUpMixin, db_base.DbTestCase):
         self.node.refresh()
         self.assertIn("Could not attach device cdrom", self.node.last_error)
         self.assertIn("disabled or not implemented", self.node.last_error)
+
+    @mock.patch.object(redfish.management.RedfishManagement,
+                       'get_virtual_media', autospec=True)
+    @mock.patch.object(redfish.management.RedfishManagement, 'validate',
+                       autospec=True)
+    def test_get_virtual_media(self, mock_validate, mock_get):
+        mock_get.return_value = [{'media_types': ['CD'], 'inserted': False,
+                                  'image': ''}]
+        result = self.service.get_virtual_media(self.context, self.node.id)
+        mock_validate.assert_called_once_with(mock.ANY, mock.ANY)
+        mock_get.assert_called_once_with(mock.ANY, mock.ANY)
+        self.assertEqual(mock_get.return_value, result)
+
+    @mock.patch.object(redfish.management.RedfishManagement,
+                       'get_virtual_media', autospec=True)
+    @mock.patch.object(redfish.management.RedfishManagement, 'validate',
+                       autospec=True)
+    def test_get_virtual_media_node_locked(self, mock_validate, mock_get):
+        """get_virtual_media uses a shared lock.
+
+        Succeeds even when the node is reserved by another operation.
+        """
+        self.node.reservation = 'fake-reserv'
+        self.node.save()
+        mock_get.return_value = [{'media_types': ['CD'], 'inserted': False,
+                                  'image': ''}]
+        result = self.service.get_virtual_media(self.context, self.node.id)
+        mock_validate.assert_called_once_with(mock.ANY, mock.ANY)
+        mock_get.assert_called_once_with(mock.ANY, mock.ANY)
+        self.assertEqual(mock_get.return_value, result)

--- a/ironic/tests/unit/drivers/modules/redfish/test_management.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_management.py
@@ -1861,7 +1861,8 @@ class RedfishManagementTestCase(db_base.DbTestCase):
 
     @mock.patch.object(redfish_boot, 'get_vmedia', autospec=True)
     def test_get_virtual_media(self, mock_get_vmedia):
-        with task_manager.acquire(self.context, self.node.uuid) as task:
+        with task_manager.acquire(self.context, self.node.uuid,
+                                  shared=True) as task:
             task.driver.management.get_virtual_media(task)
             mock_get_vmedia.assert_called_once_with(task)
 

--- a/releasenotes/notes/fix-get-vmedia-shared-lock-0caca2eabfa331ca.yaml
+++ b/releasenotes/notes/fix-get-vmedia-shared-lock-0caca2eabfa331ca.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixes a race condition where the ``GET /v1/nodes/{node}/vmedia``
+    endpoint used an exclusive node lock, causing ``NodeLocked`` (HTTP 409)
+    errors when the node was reserved by another operation. Under parallel
+    workloads (e.g. concurrent bare metal deployments), this prevented
+    callers from querying virtual media status while attach, deploy, or
+    power operations were in progress, leading to hosts failing to power on.
+    The endpoint now uses a shared lock, consistent with other read-only
+    management endpoints such as ``get_supported_boot_devices``.
+


### PR DESCRIPTION
get_virtual_media is a read-only operation that queries virtual media status from the BMC. It does not modify node state and should not require an exclusive lock.

Using an exclusive lock causes NodeLocked (HTTP 409) when the node is reserved by another operation (deploy, power change, attach vmedia). Under parallel workloads such as concurrent SNO deployments, this leads to a race condition where BMO cannot query DataImage attachment status, indefinitely blocking power-on for ~20% of hosts.

Switch to shared=True, matching the pattern used by other read-only management endpoints like get_supported_boot_devices, vif_list, and get_console_information.

Change-Id: I97574abb0ca8101090ec4ce7af1e0e891ca65026

(cherry picked from commit 0ed74588e0f010cc66d1bc72b5d7df6c53993fcd)