### PR TITLE
Pin upper constraints and constrain setuptools

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
+setuptools<82 # pkg_resources removed in setuptools 82; needed by keystonemiddleware
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.2.1 # MIT
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.2}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
+commands_pre =
+    python -I -m pip install 'setuptools<82' --force-reinstall
 commands =
     stestr run --slowest --parallel-class --exclude-regex TestMigrationsMySQL {posargs}
 passenv = http_proxy

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ commands = oslo_debug_helper -t ironic/tests/unit {posargs}
 [testenv:docs]
 # NOTE(dtantsur): documentation building process requires importing ironic
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.2}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/doc/requirements.txt
 commands = sphinx-build -b html doc/source doc/build/html
@@ -110,7 +110,7 @@ commands =
 # NOTE(Mahnoor): documentation building process requires importing ironic API modules
 usedevelop = False
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.2}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/doc/requirements.txt
 allowlist_externals = bash
@@ -121,7 +121,7 @@ commands =
 [testenv:releasenotes]
 usedevelop = False
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.2}
   -r{toxinidir}/doc/requirements.txt
 commands =
   sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
@@ -129,7 +129,7 @@ commands =
 [testenv:venv]
 setenv = PYTHONHASHSEED=0
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.2}
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/doc/requirements.txt
 commands = {posargs}


### PR DESCRIPTION
Pin upper constraints to 2023.2
Pin setuptools to fix the 'unit' CI job

```
in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib64/python3.9/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/go/src/github.com/openshift/openstack-ironic/ironic/tests/unit/common/test_wsgi_service.py", line 19, in <module>
    from ironic.common import wsgi_service
  File "/go/src/github.com/openshift/openstack-ironic/ironic/common/wsgi_service.py", line 20, in <module>
    from ironic.api import app
  File "/go/src/github.com/openshift/openstack-ironic/ironic/api/app.py", line 19, in <module>
    import keystonemiddleware.audit as audit_middleware
  File "/go/src/github.com/openshift/openstack-ironic/.tox/py3/lib/python3.9/site-packages/keystonemiddleware/audit/__init__.py", line 36, in <module>
    from keystonemiddleware._common import config
  File "/go/src/github.com/openshift/openstack-ironic/.tox/py3/lib/python3.9/site-packages/keystonemiddleware/_common/config.py", line 13, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```