### PR TITLE
Pin setuptools below 82 to fix unit test discovery

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
+setuptools<82 # pkg_resources removed in setuptools 82; needed by keystonemiddleware
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.2.1 # MIT
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
+commands_pre =
+    python -I -m pip install 'setuptools<82' --force-reinstall
 commands =
     stestr run --slowest {posargs}
 passenv = http_proxy


### PR DESCRIPTION
setuptools 82 removed pkg_resources, which keystonemiddleware still imports during test discovery. Pin setuptools in test requirements and force-reinstall it in tox before running tests.