### PR TITLE
OCPBUGS-104459: block vendor.send_raw step exposure CVE-2026-54423 (release-4.16)

### DIFF
--- a/ironic/drivers/modules/ipmitool.py
+++ b/ironic/drivers/modules/ipmitool.py
@@ -1379,24 +1379,7 @@ class VendorPassthru(base.VendorInterface):
     def __init__(self):
         _constructor_checks(driver=self.__class__.__name__)
 
-    _send_raw_step_args = {
-        'raw_bytes': {
-            'description': (
-                'A string of raw bytes to convey the request to transmit '
-                'to the remote BMC.'
-            ),
-            'required': True
-        }
-    }
-
     @METRICS.timer('VendorPassthru.send_raw')
-    @base.service_step(priority=0,
-                       argsinfo=_send_raw_step_args)
-    @base.deploy_step(priority=0,
-                      argsinfo=_send_raw_step_args)
-    @base.clean_step(priority=0, abortable=False,
-                     argsinfo=_send_raw_step_args,
-                     requires_ramdisk=False)
     @base.passthru(['POST'],
                    description=_("Send raw bytes to the BMC. Required "
                                  "argument: 'raw_bytes' - a string of raw "

--- a/ironic/tests/unit/drivers/modules/test_ipmitool.py
+++ b/ironic/tests/unit/drivers/modules/test_ipmitool.py
@@ -2208,37 +2208,6 @@ class IPMIToolDriverTestCase(Base):
                               http_method='POST',
                               raw_bytes='0x00 0x01')
 
-    def test_send_raw_bytes_is_in_step_list(self):
-        with task_manager.acquire(self.context,
-                                  self.node.uuid) as task:
-            steps = task.driver.vendor.get_clean_steps(task)
-            self.assertEqual('send_raw', steps[0]['step'])
-            self.assertEqual('vendor', steps[0]['interface'])
-            self.assertIn('raw_bytes', steps[0]['argsinfo'])
-            steps = task.driver.vendor.get_deploy_steps(task)
-            self.assertEqual('send_raw', steps[0]['step'])
-            self.assertEqual('vendor', steps[0]['interface'])
-            self.assertIn('raw_bytes', steps[0]['argsinfo'])
-
-    @mock.patch.object(ipmi, '_exec_ipmitool', autospec=True)
-    def test_send_raw_bytes_from_clean_step(self, ipmitool_mock):
-        step = {
-            'priority': 10,
-            'interface': 'vendor',
-            'step': 'send_raw',
-            'args': {'raw_bytes': '0x00 0x00 0x00 0x00'},
-            'reboot_requested': False
-        }
-        ipmitool_mock.return_value = ('', '')
-        self.node.save()
-
-        with task_manager.acquire(self.context, self.node['uuid'],
-                                  shared=False) as task:
-            task.driver.vendor.execute_clean_step(task, step)
-            ipmitool_mock.assert_called_once_with(
-                self.info,
-                'raw 0x00 0x00 0x00 0x00')
-
     @mock.patch.object(ipmi, '_exec_ipmitool', autospec=True)
     def test__bmc_reset_ok(self, mock_exec):
         mock_exec.return_value = [None, None]


### PR DESCRIPTION
## Summary

- Remove `@base.deploy_step`, `@base.clean_step`, and `@base.service_step` decorators from `VendorPassthru.send_raw` in `ironic/drivers/modules/ipmitool.py`
- Remove the `_send_raw_step_args` dict that was only used by those decorators
- Remove `test_send_raw_bytes_is_in_step_list` and `test_send_raw_bytes_from_clean_step` unit tests that assert the step registration behavior eliminated by this fix
- Prevents `send_raw` from being invoked through deploy/clean/service step workflows, eliminating the CVE-2026-54423 attack vector

## Why not cherry-pick the upstream fix?

The upstream fix (commit `7bbe5a2da24e`) adds `vendor.send_raw` to the `disallow_*_steps` config blocklist in `ironic/conf/api.py`. However, the `disallow_*_steps` config options, the `check_disallowed_steps()` function in `conductor/steps.py`, and the enforcement calls in `conductor/manager.py` do not exist on this branch. Backporting all of that infrastructure would be a large, risky change.

## What this fix does instead

Removes the step registration entirely. This achieves the same outcome as the upstream blocklist approach — `vendor.send_raw` can no longer be used as a deploy/clean/service step — but with a minimal, surgical change.

The VendorPassthru HTTP passthru API (`@base.passthru`) is preserved and continues to enforce its own RBAC. Internal callers of the module-level `send_raw()` function (used for UEFI boot device setting, etc.) are unaffected.

## Why tests were removed

`test_send_raw_bytes_is_in_step_list` and `test_send_raw_bytes_from_clean_step` validate that `send_raw` is registered as a deploy/clean step and can be executed via `execute_clean_step`. These tests assert the exact behavior that constitutes the CVE-2026-54423 vulnerability, so they are removed along with the fix.

## Bug

https://issues.redhat.com/browse/OCPBUGS-104459

## Upstream fix reference

https://github.com/openstack/ironic/commit/7bbe5a2da24e