### PR TITLE
Pin setuptools below 82 to fix unit test discovery

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+setuptools<82 # pkg_resources removed in setuptools 82; needed by keystonemiddleware
 coverage>=4.0 # Apache-2.0
 ddt>=1.2.1 # MIT
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
+commands_pre =
+    python -I -m pip install 'setuptools<82' --force-reinstall
 commands =
     stestr run --slowest --parallel-class --exclude-regex TestMigrationsMySQL {posargs}
 passenv = http_proxy


### PR DESCRIPTION
## Summary
- Pin `setuptools<82` in `test-requirements.txt` and force-reinstall in `tox.ini` `commands_pre`
- `setuptools` 82 removed `pkg_resources`, which `keystonemiddleware` still imports during test discovery, causing `ModuleNotFoundError` for all unit/pep8 tests on this branch
- Same fix already merged on `release-4.15` (PR #428) and `release-4.14`

## Test plan
- [ ] `ci/prow/unit` passes
- [ ] `ci/prow/pep8` passes

Made with [Cursor](https://cursor.com)