### PR TITLE
OCPBUGS-105862: block vendor.send_raw step exposure CVE-2026-54423(release-4.20)

### DIFF
--- a/ironic/drivers/modules/ipmitool.py
+++ b/ironic/drivers/modules/ipmitool.py
@@ -1427,24 +1427,7 @@ class VendorPassthru(base.VendorInterface):
     def __init__(self):
         _constructor_checks(driver=self.__class__.__name__)
 
-    _send_raw_step_args = {
-        'raw_bytes': {
-            'description': (
-                'A string of raw bytes to convey the request to transmit '
-                'to the remote BMC.'
-            ),
-            'required': True
-        }
-    }
-
     @METRICS.timer('VendorPassthru.send_raw')
-    @base.service_step(priority=0,
-                       argsinfo=_send_raw_step_args)
-    @base.deploy_step(priority=0,
-                      argsinfo=_send_raw_step_args)
-    @base.clean_step(priority=0, abortable=False,
-                     argsinfo=_send_raw_step_args,
-                     requires_ramdisk=False)
     @base.passthru(['POST'],
                    description=_("Send raw bytes to the BMC. Required "
                                  "argument: 'raw_bytes' - a string of raw "

--- a/ironic/tests/unit/drivers/modules/test_ipmitool.py
+++ b/ironic/tests/unit/drivers/modules/test_ipmitool.py
@@ -3021,37 +3021,6 @@ class IPMIToolDriverTestCase(Base):
                               http_method='POST',
                               raw_bytes='0x00 0x01')
 
-    def test_send_raw_bytes_is_in_step_list(self):
-        with task_manager.acquire(self.context,
-                                  self.node.uuid) as task:
-            steps = task.driver.vendor.get_clean_steps(task)
-            self.assertEqual('send_raw', steps[0]['step'])
-            self.assertEqual('vendor', steps[0]['interface'])
-            self.assertIn('raw_bytes', steps[0]['argsinfo'])
-            steps = task.driver.vendor.get_deploy_steps(task)
-            self.assertEqual('send_raw', steps[0]['step'])
-            self.assertEqual('vendor', steps[0]['interface'])
-            self.assertIn('raw_bytes', steps[0]['argsinfo'])
-
-    @mock.patch.object(ipmi, '_exec_ipmitool', autospec=True)
-    def test_send_raw_bytes_from_clean_step(self, ipmitool_mock):
-        step = {
-            'priority': 10,
-            'interface': 'vendor',
-            'step': 'send_raw',
-            'args': {'raw_bytes': '0x00 0x00 0x00 0x00'},
-            'reboot_requested': False
-        }
-        ipmitool_mock.return_value = ('', '')
-        self.node.save()
-
-        with task_manager.acquire(self.context, self.node['uuid'],
-                                  shared=False) as task:
-            task.driver.vendor.execute_clean_step(task, step)
-            ipmitool_mock.assert_called_once_with(
-                self.info,
-                'raw 0x00 0x00 0x00 0x00')
-
     @mock.patch.object(ipmi, '_exec_ipmitool', autospec=True)
     def test__bmc_reset_ok(self, mock_exec):
         mock_exec.return_value = [None, None]


### PR DESCRIPTION
## Summary

- Removes the `@base.deploy_step`, `@base.clean_step`, and `@base.service_step` decorators from `VendorPassthru.send_raw` in `ipmitool.py`, preventing `send_raw` from being invoked through deploy/clean/service workflows.
- Removes `_send_raw_step_args` dictionary that is no longer needed.
- Removes two tests (`test_send_raw_bytes_is_in_step_list` and `test_send_raw_bytes_from_clean_step`) that assert the now-removed step registration behavior.
- The `@base.passthru` HTTP API is preserved and continues to enforce its own RBAC.

## Background

The upstream fix ([openstack/ironic@7bbe5a2](https://github.com/openstack/ironic/commit/7bbe5a2da24e)) adds `vendor.send_raw` to the `disallow_*_steps` config blocklist defaults, but that config infrastructure does not exist on this branch. This alternative fix removes the step registration entirely to achieve the same security outcome.

## Tracker

- **OCPBUGS-105862**
- **CVE:** CVE-2026-54423
- **Advisory:** OSSA-2026-025


Made with [Cursor](https://cursor.com)