### PR TITLE
Pin setuptools below 82 to fix pep8 CI (release-4.17)

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+setuptools<82 # pkg_resources removed in setuptools 82; needed by keystonemiddleware
 coverage>=4.0 # Apache-2.0
 ddt>=1.2.1 # MIT
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
+commands_pre =
+    python -I -m pip install 'setuptools<82' --force-reinstall
 commands =
     stestr run --slowest --parallel-class --exclude-regex TestMigrationsMySQL {posargs}
 passenv = http_proxy


### PR DESCRIPTION
## Summary

- Pins `setuptools<82` in `test-requirements.txt` and force-reinstalls it via `commands_pre` in `tox.ini`.

## Background

`setuptools` 82 removed `pkg_resources`, which is still required by `keystonemiddleware` and `flake8-import-order` in the test environment. Without this pin, the pep8 CI job fails with:

```
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "flake8-import-order" due to No module named 'pkg_resources'.
```

Same fix as applied on release-4.16.


Made with [Cursor](https://cursor.com)