### PR TITLE
[release-4.19] OCPBUGS-88476: Add an agent flag to disable installing boatloaders

### DIFF
--- a/ironic/api/controllers/v1/ramdisk.py
+++ b/ironic/api/controllers/v1/ramdisk.py
@@ -74,6 +74,7 @@ def config(token):
         'agent_md5_checksum_enable': CONF.agent.allow_md5_checksum,
         'disable_deep_image_inspection': CONF.conductor.disable_deep_image_inspection,  # noqa
         'permitted_image_formats': CONF.conductor.permitted_image_formats,
+        'enable_bios_bootloader_install': CONF.agent.enable_bios_bootloader_install, # noqa
     }
 
 

--- a/ironic/conf/agent.py
+++ b/ironic/conf/agent.py
@@ -180,6 +180,14 @@ opts = [
                        'permitted to consider MD5 checksums. This option '
                        'is expected to change to a default of False in a '
                        '2024 release of Ironic.')),
+    cfg.BoolOpt('enable_bios_bootloader_install',
+                default=False,
+                help=_('When enabled, enables agent support for partition '
+                       'images which require a legacy bootloader -- and a '
+                       'call to ``grub-install``. Generally, this should '
+                       'remain disabled for maximum security, however, this '
+                       'option allows it to be re-enabled for '
+                       'compatibility.')),
 ]
 
 

--- a/ironic/tests/unit/api/controllers/v1/test_ramdisk.py
+++ b/ironic/tests/unit/api/controllers/v1/test_ramdisk.py
@@ -97,6 +97,7 @@ class TestLookup(test_api_base.BaseApiTest):
             'agent_md5_checksum_enable': CONF.agent.allow_md5_checksum,
             'disable_deep_image_inspection': CONF.conductor.disable_deep_image_inspection,  # noqa
             'permitted_image_formats': CONF.conductor.permitted_image_formats,
+            'enable_bios_bootloader_install': CONF.agent.enable_bios_bootloader_install, # noqa
         }
         self.assertEqual(expected_config, data['config'])
         self.assertIsNotNone(data['config']['agent_token'])

--- a/releasenotes/notes/disable-installing-bootloaders-by-default-4a3c69777069587c.yaml
+++ b/releasenotes/notes/disable-installing-bootloaders-by-default-4a3c69777069587c.yaml
@@ -1,0 +1,9 @@
+---
+security:
+  - |
+    Disable installation of bootloaders (via grub-install) by IPA by default
+    in order to improve security posture by adding a new agent configuration
+    option `enable_bios_bootloader_install` which defaults to `False`.
+    Operators who still need this functionality can re-enable installation of
+    bootloaders by setting `enable_bios_bootloader_install` to `True`.
+    Addresses CVE-2026-43003.


### PR DESCRIPTION
Pipes the new agent flag (enable_bios_bootloader_install) to agents. This flag disables bootloader install (calls to grub-install) by default for security reasons.

Part of mitigation of CVE-2026-43003.

Related-Bug: 2148310
Change-Id: I694bbe121e09e7e0b2e6c5ab3746f7943385190a

(cherry picked from commit e38ae0c579f8f05a85fc3266910525f96877dec5) (cherry picked from commit 9a8d91adb3a4ba9eaebc135744d0e04ad3c66327) (cherry picked from commit 0fb6ca6e250702eac9bcabcd25f498eadcd38544) (cherry picked from commit 008be867dfbd6e6db5e82dad20700a507e77e083)