### PR TITLE
[release-4.20] OCPBUGS-111100: Use ServiceRoot.Vendor for detect_vendor() instead of System.Manufacturer

### DIFF
--- a/ironic/drivers/modules/redfish/management.py
+++ b/ironic/drivers/modules/redfish/management.py
@@ -1042,7 +1042,9 @@ class RedfishManagement(base.ManagementInterface):
     def detect_vendor(self, task):
         """Detects and returns the hardware vendor.
 
-        Uses the System's Manufacturer field.
+        Uses the Service Root's Vendor field to identify the BMC firmware
+        vendor. Falls back to the System's Manufacturer field if Vendor
+        is not available in the Service Root.
 
         :param task: A task from TaskManager.
         :raises: InvalidParameterValue if an invalid component, indicator
@@ -1052,6 +1054,9 @@ class RedfishManagement(base.ManagementInterface):
         :returns: String representing the BMC reported Vendor or
                   Manufacturer, otherwise returns None.
         """
+        vendor = redfish_utils.get_root_vendor(task.node)
+        if vendor:
+            return vendor
         return redfish_utils.get_system(task.node).manufacturer
 
     @METRICS.timer('RedfishManagement.update_firmware')

--- a/ironic/drivers/modules/redfish/utils.py
+++ b/ironic/drivers/modules/redfish/utils.py
@@ -405,6 +405,21 @@ def get_system(node):
         raise exception.RedfishError(error=e)
 
 
+def get_root_vendor(node):
+    """Get the BMC vendor from the Redfish Service Root.
+
+    :param node: an Ironic node object
+    :returns: The Vendor string from the ServiceRoot, or None
+    """
+    try:
+        return _get_connection(node, lambda conn: conn.json.get('Vendor'))
+    except Exception as e:
+        LOG.debug('Failed to get vendor from the Redfish Service Root '
+                  'for node %(node)s. Error %(error)s',
+                  {'node': node.uuid, 'error': e})
+        return None
+
+
 def get_system_collection(node):
     """Get a Redfish System Collection that includes the node
 

--- a/ironic/tests/unit/drivers/modules/redfish/test_management.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_management.py
@@ -981,7 +981,31 @@ class RedfishManagementTestCase(db_base.DbTestCase):
             self.assertEqual(indicator_states.ON, state)
 
     @mock.patch.object(redfish_utils, 'get_system', autospec=True)
-    def test_detect_vendor(self, mock_get_system):
+    @mock.patch.object(redfish_utils, 'get_root_vendor', autospec=True)
+    def test_detect_vendor(self, mock_get_root_vendor, mock_get_system):
+        mock_get_root_vendor.return_value = "AMI"
+        with task_manager.acquire(self.context, self.node.uuid,
+                                  shared=True) as task:
+            response = task.driver.management.detect_vendor(task)
+            self.assertEqual("AMI", response)
+            mock_get_system.assert_not_called()
+
+    @mock.patch.object(redfish_utils, 'get_system', autospec=True)
+    @mock.patch.object(redfish_utils, 'get_root_vendor', autospec=True)
+    def test_detect_vendor_no_root_vendor(self, mock_get_root_vendor,
+                                          mock_get_system):
+        mock_get_root_vendor.return_value = None
+        mock_get_system.return_value.manufacturer = "Fake GmbH"
+        with task_manager.acquire(self.context, self.node.uuid,
+                                  shared=True) as task:
+            response = task.driver.management.detect_vendor(task)
+            self.assertEqual("Fake GmbH", response)
+
+    @mock.patch.object(redfish_utils, 'get_system', autospec=True)
+    @mock.patch.object(redfish_utils, 'get_root_vendor', autospec=True)
+    def test_detect_vendor_root_vendor_empty(self, mock_get_root_vendor,
+                                             mock_get_system):
+        mock_get_root_vendor.return_value = ""
         mock_get_system.return_value.manufacturer = "Fake GmbH"
         with task_manager.acquire(self.context, self.node.uuid,
                                   shared=True) as task:

--- a/ironic/tests/unit/drivers/modules/redfish/test_utils.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_utils.py
@@ -218,6 +218,22 @@ class RedfishUtilsTestCase(db_base.DbTestCase):
         self.assertRaises(exception.RedfishError,
                           redfish_utils.get_update_service, self.node)
 
+    def test_get_root_vendor(self):
+        redfish_utils._get_connection = mock.Mock()
+        redfish_utils._get_connection.return_value = "AMI"
+
+        result = redfish_utils.get_root_vendor(self.node)
+
+        self.assertEqual("AMI", result)
+
+    def test_get_root_vendor_error(self):
+        redfish_utils._get_connection = mock.Mock()
+        redfish_utils._get_connection.side_effect = Exception('conn failed')
+
+        result = redfish_utils.get_root_vendor(self.node)
+
+        self.assertIsNone(result)
+
     def test_get_event_service(self):
         redfish_utils._get_connection = mock.Mock()
         mock_event_service = mock.Mock()

--- a/releasenotes/notes/fix-detect-vendor-serviceroot-vendor-f8adfe5640316e97.yaml
+++ b/releasenotes/notes/fix-detect-vendor-serviceroot-vendor-f8adfe5640316e97.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixes vendor detection for systems where the BMC firmware vendor differs
+    from the chassis OEM. The detect_vendor() method now reads the Vendor field
+    from the Redfish Service Root (/redfish/v1/) which identifies the BMC
+    firmware vendor, rather than System.Manufacturer which reflects the
+    chassis OEM. This prevents incorrect firmware compatibility checks and
+    ensures vendor-specific code paths are triggered correctly. Falls
+    back to System.Manufacturer when ServiceRoot.Vendor is not available.


### PR DESCRIPTION
Some systems like Dell GB200 NVL servers use AMI MegaRAC BMCs rebranded under Dell. System.Manufacturer returns "Dell Inc." (the chassis OEM), but the BMC firmware is actually AMI. This causes detect_vendor() to misidentify the vendor, triggering the wrong firmware version check and missing AMI-specific code paths.

Prefer the Redfish ServiceRoot Vendor field which correctly identifies the BMC firmware vendor. Fall back to System.Manufacturer when ServiceRoot.Vendor is not available.

Closes-Bug: #2143027

Change-Id: Ib988ed6b84848e9b479f40255e2175f70751d61f

(cherry picked from commit 84ff8241cd9e44c702ffeb8896386eb139a2cffe) (cherry picked from commit bf6187bb3dd89c93973aa55b592f0b219b39d26a)